### PR TITLE
Fix: Process Tree Nodes once after restart

### DIFF
--- a/ldi-core/ldes-client/tree-node-supplier/pom.xml
+++ b/ldi-core/ldes-client/tree-node-supplier/pom.xml
@@ -45,8 +45,6 @@
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
         </dependency>
-
-
     </dependencies>
 
 </project>

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
@@ -4,10 +4,8 @@ import ldes.client.treenodefetcher.TreeNodeFetcher;
 import ldes.client.treenodefetcher.domain.valueobjects.TreeNodeResponse;
 import ldes.client.treenodesupplier.domain.entities.MemberRecord;
 import ldes.client.treenodesupplier.domain.entities.TreeNodeRecord;
-import ldes.client.treenodesupplier.domain.services.MemberRepositoryFactory;
-import ldes.client.treenodesupplier.domain.services.TreeNodeRecordRepositoryFactory;
 import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
-import ldes.client.treenodesupplier.domain.valueobject.StatePersistenceStrategy;
+import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.SuppliedMember;
 import ldes.client.treenodesupplier.domain.valueobject.TreeNodeStatus;
 import ldes.client.treenodesupplier.repository.MemberRepository;
@@ -26,24 +24,14 @@ public class TreeNodeProcessor {
 	private final TreeNodeFetcher treeNodeFetcher;
 	private final StartingTreeNode startingTreeNode;
 
-	public TreeNodeProcessor(StartingTreeNode startingTreeNode,
-			TreeNodeRecordRepository treeNodeRecordRepository,
-			MemberRepository memberRepository,
+	public TreeNodeProcessor(StartingTreeNode startingTreeNode, StatePersistence statePersistence,
 			TreeNodeFetcher treeNodeFetcher) {
-		this.treeNodeRecordRepository = treeNodeRecordRepository;
-		this.memberRepository = memberRepository;
+		this.treeNodeRecordRepository = statePersistence.getTreeNodeRecordRepository();
+		this.memberRepository = statePersistence.getMemberRepository();
 		this.treeNodeFetcher = treeNodeFetcher;
-		this.treeNodeRecordRepository.saveTreeNodeRecord(new TreeNodeRecord(startingTreeNode.getStartingNodeUrl()));
-		this.startingTreeNode = startingTreeNode;
-	}
-
-	public TreeNodeProcessor(StartingTreeNode startingTreeNode, StatePersistenceStrategy statePersistenceStrategy,
-			TreeNodeFetcher treeNodeFetcher) {
-		this.treeNodeRecordRepository = TreeNodeRecordRepositoryFactory
-				.getTreeNodeRecordRepository(statePersistenceStrategy);
-		this.memberRepository = MemberRepositoryFactory.getMemberRepository(statePersistenceStrategy);
-		this.treeNodeFetcher = treeNodeFetcher;
-		this.treeNodeRecordRepository.saveTreeNodeRecord(new TreeNodeRecord(startingTreeNode.getStartingNodeUrl()));
+		if (!treeNodeRecordRepository.existsById(startingTreeNode.getStartingNodeUrl())) {
+			this.treeNodeRecordRepository.saveTreeNodeRecord(new TreeNodeRecord(startingTreeNode.getStartingNodeUrl()));
+		}
 		this.startingTreeNode = startingTreeNode;
 	}
 

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/domain/valueobject/StatePersistence.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/domain/valueobject/StatePersistence.java
@@ -1,0 +1,31 @@
+package ldes.client.treenodesupplier.domain.valueobject;
+
+import ldes.client.treenodesupplier.domain.services.MemberRepositoryFactory;
+import ldes.client.treenodesupplier.domain.services.TreeNodeRecordRepositoryFactory;
+import ldes.client.treenodesupplier.repository.MemberRepository;
+import ldes.client.treenodesupplier.repository.TreeNodeRecordRepository;
+
+public class StatePersistence {
+
+	private final MemberRepository memberRepository;
+	private final TreeNodeRecordRepository treeNodeRecordRepository;
+
+	public StatePersistence(MemberRepository memberRepository, TreeNodeRecordRepository treeNodeRecordRepository) {
+		this.memberRepository = memberRepository;
+		this.treeNodeRecordRepository = treeNodeRecordRepository;
+	}
+
+	public static StatePersistence from(StatePersistenceStrategy statePersistenceStrategy) {
+		return new StatePersistence(MemberRepositoryFactory.getMemberRepository(statePersistenceStrategy),
+				TreeNodeRecordRepositoryFactory
+						.getTreeNodeRecordRepository(statePersistenceStrategy));
+	}
+
+	public MemberRepository getMemberRepository() {
+		return memberRepository;
+	}
+
+	public TreeNodeRecordRepository getTreeNodeRecordRepository() {
+		return treeNodeRecordRepository;
+	}
+}

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/TreeNodeRecordRepository.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/TreeNodeRecordRepository.java
@@ -15,4 +15,5 @@ public interface TreeNodeRecordRepository {
 	boolean existsByIdAndStatus(String treeNodeId, TreeNodeStatus treeNodeStatus);
 
 	void destroyState();
+
 }

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/EntityManagerFactory.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/EntityManagerFactory.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import javax.persistence.EntityManager;
 import javax.persistence.Persistence;
 
+@SuppressWarnings("java:S2696")
 public class EntityManagerFactory {
 
 	private static EntityManagerFactory instance = null;
@@ -37,6 +38,7 @@ public class EntityManagerFactory {
 		try {
 			em.close();
 			emf.close();
+			instance = null;
 			if (!databaseDeleted) {
 				Files.delete(Path.of("database.db"));
 				databaseDeleted = true;

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/SqliteTreeNodeRepository.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/SqliteTreeNodeRepository.java
@@ -53,4 +53,5 @@ public class SqliteTreeNodeRepository implements TreeNodeRecordRepository {
 	public void destroyState() {
 		entityManagerFactory.destroyState();
 	}
+
 }

--- a/ldi-core/ldes-client/tree-node-supplier/src/test/java/ldes/client/treenodesupplier/MemberSupplierSteps.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/test/java/ldes/client/treenodesupplier/MemberSupplierSteps.java
@@ -10,6 +10,7 @@ import ldes.client.treenodesupplier.domain.entities.MemberRecord;
 import ldes.client.treenodesupplier.domain.services.MemberRepositoryFactory;
 import ldes.client.treenodesupplier.domain.services.TreeNodeRecordRepositoryFactory;
 import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
+import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistenceStrategy;
 import ldes.client.treenodesupplier.domain.valueobject.TreeNodeStatus;
 import ldes.client.treenodesupplier.repository.MemberRepository;
@@ -44,7 +45,7 @@ public class MemberSupplierSteps {
 		assertTrue(treeNodeRecordRepository.existsById(treeNodeId));
 	}
 
-	@Then("The TreeNode is not processed: {string}")
+	@And("The TreeNode is not processed: {string}")
 	public void theTreeNodeIsNotProcessed(String treeNodeId) {
 		assertFalse(treeNodeRecordRepository.existsById(treeNodeId));
 	}
@@ -62,7 +63,8 @@ public class MemberSupplierSteps {
 
 	@When("I create a Processor")
 	public void iCreateAProcessor() {
-		treeNodeProcessor = new TreeNodeProcessor(startingTreeNode, treeNodeRecordRepository, memberRepository,
+		treeNodeProcessor = new TreeNodeProcessor(startingTreeNode,
+				new StatePersistence(memberRepository, treeNodeRecordRepository),
 				new TreeNodeFetcher(new DefaultConfig().createRequestExecutor()));
 	}
 
@@ -88,5 +90,10 @@ public class MemberSupplierSteps {
 		memberRepository = MemberRepositoryFactory.getMemberRepository(StatePersistenceStrategy.SQLITE);
 		treeNodeRecordRepository = TreeNodeRecordRepositoryFactory
 				.getTreeNodeRecordRepository(StatePersistenceStrategy.SQLITE);
+	}
+
+	@Then("MemberSupplier is destroyed")
+	public void membersupplierIsDestroyed() {
+		memberSupplier.destroyState();
 	}
 }

--- a/ldi-core/ldes-client/tree-node-supplier/src/test/resources/features/restart-client.feature
+++ b/ldi-core/ldes-client/tree-node-supplier/src/test/resources/features/restart-client.feature
@@ -1,10 +1,10 @@
-Feature: MemberSupplier
+Feature: Restart MemberSupplier
   As a user
-  I want get a stream of Members from the MemberSupplier
+  I want to stop and restart the MemberSupplier and use the persistent state
 
-  Scenario Outline: Obtaining the members from first three fragments including the starting node
+  Scenario: Obtaining the members from first three fragments including the starting node
     Given A starting url "http://localhost:10101/302-redirects-to-first-node"
-    And a StatePersistenceStrategy <statePersistenceStrategy>
+    And a StatePersistenceStrategy SQLITE
     And The TreeNode is not processed: "http://localhost:10101/200-first-tree-node"
     When I create a Processor
     Then Status "NOT_VISITED" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"
@@ -18,12 +18,16 @@ Feature: MemberSupplier
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/1" is processed
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/2" is not processed
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/3" is not processed
+# Restart
+    When I create a MemberSupplier
     When I request the 1 members from the MemberSupplier
     Then Status "IMMUTABLE" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"
     Then Status "MUTABLE_AND_ACTIVE" for TreeNodeRecord with identifier: "http://localhost:10101/200-second-tree-node"
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/1" is processed
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/2" is processed
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/3" is not processed
+# Restart
+    When I create a MemberSupplier
     When I request the 1 members from the MemberSupplier
     Then Status "IMMUTABLE" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"
     Then Status "MUTABLE_AND_ACTIVE" for TreeNodeRecord with identifier: "http://localhost:10101/200-second-tree-node"
@@ -31,8 +35,3 @@ Feature: MemberSupplier
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/2" is processed
     Then Member "https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/3" is processed
     Then MemberSupplier is destroyed
-
-    Examples:
-      | statePersistenceStrategy |
-      | MEMORY                   |
-      | SQLITE                   |

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
@@ -11,6 +11,7 @@ import ldes.client.treenodesupplier.MemberSupplier;
 import ldes.client.treenodesupplier.StartingTreeNodeSupplier;
 import ldes.client.treenodesupplier.TreeNodeProcessor;
 import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
+import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.SuppliedMember;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
@@ -71,7 +72,7 @@ public class LdesClient extends AbstractProcessor {
 		StartingTreeNode startingTreeNode = new StartingTreeNodeSupplier(requestExecutor).getStart(dataSourceUrl,
 				dataSourceFormat);
 		TreeNodeProcessor treeNodeProcessor = new TreeNodeProcessor(startingTreeNode,
-				LdesProcessorProperties.getStatePersistenceStrategy(context),
+				StatePersistence.from(LdesProcessorProperties.getStatePersistenceStrategy(context)),
 				new TreeNodeFetcher(requestExecutor));
 		memberSupplier = new MemberSupplier(treeNodeProcessor, LdesProcessorProperties.stateKept(context));
 

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdesClientRunner.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdesClientRunner.java
@@ -8,6 +8,7 @@ import ldes.client.treenodesupplier.MemberSupplier;
 import ldes.client.treenodesupplier.StartingTreeNodeSupplier;
 import ldes.client.treenodesupplier.TreeNodeProcessor;
 import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
+import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistenceStrategy;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFLanguages;
@@ -64,7 +65,7 @@ public class LdesClientRunner implements Runnable {
 			RequestExecutor requestExecutor,
 			StartingTreeNode startingTreeNode) {
 
-		return new TreeNodeProcessor(startingTreeNode, statePersistenceStrategy,
+		return new TreeNodeProcessor(startingTreeNode, StatePersistence.from(statePersistenceStrategy),
 				new TreeNodeFetcher(requestExecutor));
 	}
 


### PR DESCRIPTION
Fix to process tree nodes once after restart.
If there are already treenodes available, it means the client has already processed part of the ldes stream.