### PR TITLE
Fix: Use HikariConnectionProvider for database connections

### DIFF
--- a/ldi-core/ldes-client/pom.xml
+++ b/ldi-core/ldes-client/pom.xml
@@ -24,7 +24,7 @@
         <sqlite-dialect.version>0.1.4</sqlite-dialect.version>
         <junit-platform-suite.version>1.9.3</junit-platform-suite.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
-
+        <hikari.version>5.0.1</hikari.version>
     </properties>
 
     <dependencies>

--- a/ldi-core/ldes-client/tree-node-supplier/pom.xml
+++ b/ldi-core/ldes-client/tree-node-supplier/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/resources/META-INF/persistence.xml
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/resources/META-INF/persistence.xml
@@ -17,6 +17,7 @@
             <property name="javax.persistence.jdbc.driver" value="org.sqlite.JDBC"/>
             <property name="javax.persistence.jdbc.url" value="jdbc:sqlite:database.db"/>
 
+            <property name="hibernate.connection.provider_class" value="com.zaxxer.hikari.hibernate.HikariConnectionProvider" />
         </properties>
 
     </persistence-unit>


### PR DESCRIPTION
Use the HikariConnectionProvider instead of the built-in (which is not for production).