### PR TITLE
Fix: Client only determines the starting node if no other nodes have been processed

### DIFF
--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
@@ -25,7 +25,7 @@ public class TreeNodeProcessor {
 	private MemberRecord memberRecord;
 
 	public TreeNodeProcessor(LdesMetaData ldesMetaData, StatePersistence statePersistence,
-                             RequestExecutor requestExecutor) {
+			RequestExecutor requestExecutor) {
 		this.treeNodeRecordRepository = statePersistence.getTreeNodeRecordRepository();
 		this.memberRepository = statePersistence.getMemberRepository();
 		this.requestExecutor = requestExecutor;

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
@@ -20,17 +20,17 @@ public class TreeNodeProcessor {
 	private final TreeNodeRecordRepository treeNodeRecordRepository;
 	private final MemberRepository memberRepository;
 	private final TreeNodeFetcher treeNodeFetcher;
-	private final LdesDescription ldesDescription;
+	private final LdesMetaData ldesMetaData;
 	private final RequestExecutor requestExecutor;
 	private MemberRecord memberRecord;
 
-	public TreeNodeProcessor(LdesDescription ldesDescription, StatePersistence statePersistence,
-			RequestExecutor requestExecutor) {
+	public TreeNodeProcessor(LdesMetaData ldesMetaData, StatePersistence statePersistence,
+                             RequestExecutor requestExecutor) {
 		this.treeNodeRecordRepository = statePersistence.getTreeNodeRecordRepository();
 		this.memberRepository = statePersistence.getMemberRepository();
 		this.requestExecutor = requestExecutor;
 		this.treeNodeFetcher = new TreeNodeFetcher(requestExecutor);
-		this.ldesDescription = ldesDescription;
+		this.ldesMetaData = ldesMetaData;
 	}
 
 	private void processTreeNode() {
@@ -41,7 +41,7 @@ public class TreeNodeProcessor {
 										"No fragments to mutable or new fragments to process -> LDES ends.")));
 		waitUntilNextVisit(treeNodeRecord);
 		TreeNodeResponse treeNodeResponse = treeNodeFetcher
-				.fetchTreeNode(ldesDescription.createRequest(treeNodeRecord.getTreeNodeUrl()));
+				.fetchTreeNode(ldesMetaData.createRequest(treeNodeRecord.getTreeNodeUrl()));
 		treeNodeRecord.updateStatus(treeNodeResponse.getMutabilityStatus());
 		treeNodeRecordRepository.saveTreeNodeRecord(treeNodeRecord);
 		treeNodeResponse.getRelations()
@@ -88,7 +88,7 @@ public class TreeNodeProcessor {
 
 	private void initializeTreeNodeRecordRepository() {
 		StartingTreeNode start = new StartingTreeNodeSupplier(requestExecutor)
-				.getStart(ldesDescription.getStartingNodeUrl(), ldesDescription.getLang());
+				.getStart(ldesMetaData.getStartingNodeUrl(), ldesMetaData.getLang());
 		treeNodeRecordRepository.saveTreeNodeRecord(new TreeNodeRecord(start.getStartingNodeUrl()));
 	}
 

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/TreeNodeProcessor.java
@@ -1,13 +1,11 @@
 package ldes.client.treenodesupplier;
 
+import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.RequestExecutor;
 import ldes.client.treenodefetcher.TreeNodeFetcher;
 import ldes.client.treenodefetcher.domain.valueobjects.TreeNodeResponse;
 import ldes.client.treenodesupplier.domain.entities.MemberRecord;
 import ldes.client.treenodesupplier.domain.entities.TreeNodeRecord;
-import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
-import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
-import ldes.client.treenodesupplier.domain.valueobject.SuppliedMember;
-import ldes.client.treenodesupplier.domain.valueobject.TreeNodeStatus;
+import ldes.client.treenodesupplier.domain.valueobject.*;
 import ldes.client.treenodesupplier.repository.MemberRepository;
 import ldes.client.treenodesupplier.repository.TreeNodeRecordRepository;
 
@@ -22,19 +20,17 @@ public class TreeNodeProcessor {
 	private final TreeNodeRecordRepository treeNodeRecordRepository;
 	private final MemberRepository memberRepository;
 	private final TreeNodeFetcher treeNodeFetcher;
-	private final StartingTreeNode startingTreeNode;
-
+	private final LdesDescription ldesDescription;
+	private final RequestExecutor requestExecutor;
 	private MemberRecord memberRecord;
 
-	public TreeNodeProcessor(StartingTreeNode startingTreeNode, StatePersistence statePersistence,
-			TreeNodeFetcher treeNodeFetcher) {
+	public TreeNodeProcessor(LdesDescription ldesDescription, StatePersistence statePersistence,
+			RequestExecutor requestExecutor) {
 		this.treeNodeRecordRepository = statePersistence.getTreeNodeRecordRepository();
 		this.memberRepository = statePersistence.getMemberRepository();
-		this.treeNodeFetcher = treeNodeFetcher;
-		if (!treeNodeRecordRepository.existsById(startingTreeNode.getStartingNodeUrl())) {
-			this.treeNodeRecordRepository.saveTreeNodeRecord(new TreeNodeRecord(startingTreeNode.getStartingNodeUrl()));
-		}
-		this.startingTreeNode = startingTreeNode;
+		this.requestExecutor = requestExecutor;
+		this.treeNodeFetcher = new TreeNodeFetcher(requestExecutor);
+		this.ldesDescription = ldesDescription;
 	}
 
 	private void processTreeNode() {
@@ -45,7 +41,7 @@ public class TreeNodeProcessor {
 										"No fragments to mutable or new fragments to process -> LDES ends.")));
 		waitUntilNextVisit(treeNodeRecord);
 		TreeNodeResponse treeNodeResponse = treeNodeFetcher
-				.fetchTreeNode(startingTreeNode.createRequest(treeNodeRecord.getTreeNodeUrl()));
+				.fetchTreeNode(ldesDescription.createRequest(treeNodeRecord.getTreeNodeUrl()));
 		treeNodeRecord.updateStatus(treeNodeResponse.getMutabilityStatus());
 		treeNodeRecordRepository.saveTreeNodeRecord(treeNodeRecord);
 		treeNodeResponse.getRelations()
@@ -74,8 +70,9 @@ public class TreeNodeProcessor {
 	}
 
 	public SuppliedMember getMember() {
-		if (memberRecord != null) {
-			memberRepository.saveTreeMember(memberRecord);
+		savePreviousState();
+		if (!treeNodeRecordRepository.containsTreeNodeRecords()) {
+			initializeTreeNodeRecordRepository();
 		}
 		Optional<MemberRecord> unprocessedTreeMember = memberRepository.getUnprocessedTreeMember();
 		while (unprocessedTreeMember.isEmpty()) {
@@ -87,6 +84,18 @@ public class TreeNodeProcessor {
 		treeMember.processedMemberRecord();
 		memberRecord = treeMember;
 		return suppliedMember;
+	}
+
+	private void initializeTreeNodeRecordRepository() {
+		StartingTreeNode start = new StartingTreeNodeSupplier(requestExecutor)
+				.getStart(ldesDescription.getStartingNodeUrl(), ldesDescription.getLang());
+		treeNodeRecordRepository.saveTreeNodeRecord(new TreeNodeRecord(start.getStartingNodeUrl()));
+	}
+
+	private void savePreviousState() {
+		if (memberRecord != null) {
+			memberRepository.saveTreeMember(memberRecord);
+		}
 	}
 
 	public void destroyState() {

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/domain/valueobject/LdesDescription.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/domain/valueobject/LdesDescription.java
@@ -1,0 +1,26 @@
+package ldes.client.treenodesupplier.domain.valueobject;
+
+import ldes.client.treenodefetcher.domain.valueobjects.TreeNodeRequest;
+import org.apache.jena.riot.Lang;
+
+public class LdesDescription {
+	private final String startingNodeUrl;
+	private final Lang lang;
+
+	public LdesDescription(String startingNodeUrl, Lang lang) {
+		this.startingNodeUrl = startingNodeUrl;
+		this.lang = lang;
+	}
+
+	public String getStartingNodeUrl() {
+		return startingNodeUrl;
+	}
+
+	public TreeNodeRequest createRequest(String treeNodeUrl) {
+		return new TreeNodeRequest(treeNodeUrl, lang, null);
+	}
+
+	public Lang getLang() {
+		return lang;
+	}
+}

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/domain/valueobject/LdesMetaData.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/domain/valueobject/LdesMetaData.java
@@ -3,11 +3,11 @@ package ldes.client.treenodesupplier.domain.valueobject;
 import ldes.client.treenodefetcher.domain.valueobjects.TreeNodeRequest;
 import org.apache.jena.riot.Lang;
 
-public class LdesDescription {
+public class LdesMetaData {
 	private final String startingNodeUrl;
 	private final Lang lang;
 
-	public LdesDescription(String startingNodeUrl, Lang lang) {
+	public LdesMetaData(String startingNodeUrl, Lang lang) {
 		this.startingNodeUrl = startingNodeUrl;
 		this.lang = lang;
 	}

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/TreeNodeRecordRepository.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/TreeNodeRecordRepository.java
@@ -16,4 +16,5 @@ public interface TreeNodeRecordRepository {
 
 	void destroyState();
 
+	boolean containsTreeNodeRecords();
 }

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/inmemory/InMemoryTreeNodeRecordRepository.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/inmemory/InMemoryTreeNodeRecordRepository.java
@@ -48,6 +48,12 @@ public class InMemoryTreeNodeRecordRepository implements TreeNodeRecordRepositor
 		immutable = new ArrayList<>();
 	}
 
+	@Override
+	public boolean containsTreeNodeRecords() {
+		return Stream.of(notVisited, mutableAndActive, immutable)
+				.anyMatch(treeNodeRecords -> !treeNodeRecords.isEmpty());
+	}
+
 	public Optional<TreeNodeRecord> getOneTreeNodeRecordWithStatus(TreeNodeStatus treeNodeStatus) {
 		return switch (treeNodeStatus) {
 			case NOT_VISITED -> notVisited.isEmpty() ? Optional.empty() : Optional.of(notVisited.get(0));

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/SqliteTreeNodeRepository.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/SqliteTreeNodeRepository.java
@@ -54,4 +54,11 @@ public class SqliteTreeNodeRepository implements TreeNodeRecordRepository {
 		entityManagerFactory.destroyState();
 	}
 
+	@Override
+	public boolean containsTreeNodeRecords() {
+		return entityManager
+				.createNamedQuery("TreeNode.count", Long.class)
+				.getSingleResult() > 0;
+	}
+
 }

--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/TreeNodeRecordEntity.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/TreeNodeRecordEntity.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.NamedQuery;
 
 @Entity
+@NamedQuery(name = "TreeNode.count", query = "SELECT COUNT(t) FROM TreeNodeRecordEntity t")
 @NamedQuery(name = "TreeNode.countById", query = "SELECT COUNT(t) FROM TreeNodeRecordEntity t WHERE t.id = :id")
 @NamedQuery(name = "TreeNode.countByIdAndStatus", query = "SELECT COUNT(t) FROM TreeNodeRecordEntity t WHERE t.id = :id and t.treeNodeStatus = :treeNodeStatus")
 @NamedQuery(name = "TreeNode.getByTreeNodeStatus", query = "SELECT t FROM TreeNodeRecordEntity t WHERE t.treeNodeStatus = :treeNodeStatus")

--- a/ldi-core/ldes-client/tree-node-supplier/src/test/java/ldes/client/treenodesupplier/MemberSupplierSteps.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/test/java/ldes/client/treenodesupplier/MemberSupplierSteps.java
@@ -25,7 +25,7 @@ public class MemberSupplierSteps {
 	private TreeNodeRecordRepository treeNodeRecordRepository;
 	private MemberRepository memberRepository;
 	private MemberSupplier memberSupplier;
-	private LdesDescription ldesDescription;
+	private LdesMetaData ldesMetaData;
 	private SuppliedMember suppliedMember;
 
 	@When("I request one member from the MemberSupplier")
@@ -55,13 +55,13 @@ public class MemberSupplierSteps {
 
 	@Given("A starting url {string}")
 	public void aStartingUrl(String url) {
-		ldesDescription = new LdesDescription(url,
+		ldesMetaData = new LdesMetaData(url,
 				Lang.JSONLD);
 	}
 
 	@When("I create a Processor")
 	public void iCreateAProcessor() {
-		treeNodeProcessor = new TreeNodeProcessor(ldesDescription,
+		treeNodeProcessor = new TreeNodeProcessor(ldesMetaData,
 				new StatePersistence(memberRepository, treeNodeRecordRepository),
 				new DefaultConfig().createRequestExecutor());
 	}

--- a/ldi-core/ldes-client/tree-node-supplier/src/test/java/ldes/client/treenodesupplier/MemberSupplierSteps.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/test/java/ldes/client/treenodesupplier/MemberSupplierSteps.java
@@ -5,7 +5,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import ldes.client.treenodefetcher.TreeNodeFetcher;
 import ldes.client.treenodesupplier.domain.services.MemberRepositoryFactory;
 import ldes.client.treenodesupplier.domain.services.TreeNodeRecordRepositoryFactory;
 import ldes.client.treenodesupplier.domain.valueobject.*;
@@ -26,7 +25,7 @@ public class MemberSupplierSteps {
 	private TreeNodeRecordRepository treeNodeRecordRepository;
 	private MemberRepository memberRepository;
 	private MemberSupplier memberSupplier;
-	private StartingTreeNode startingTreeNode;
+	private LdesDescription ldesDescription;
 	private SuppliedMember suppliedMember;
 
 	@When("I request one member from the MemberSupplier")
@@ -56,15 +55,15 @@ public class MemberSupplierSteps {
 
 	@Given("A starting url {string}")
 	public void aStartingUrl(String url) {
-		startingTreeNode = new StartingTreeNodeSupplier(new DefaultConfig().createRequestExecutor()).getStart(url,
+		ldesDescription = new LdesDescription(url,
 				Lang.JSONLD);
 	}
 
 	@When("I create a Processor")
 	public void iCreateAProcessor() {
-		treeNodeProcessor = new TreeNodeProcessor(startingTreeNode,
+		treeNodeProcessor = new TreeNodeProcessor(ldesDescription,
 				new StatePersistence(memberRepository, treeNodeRecordRepository),
-				new TreeNodeFetcher(new DefaultConfig().createRequestExecutor()));
+				new DefaultConfig().createRequestExecutor());
 	}
 
 	@Then("Member {string} is processed")

--- a/ldi-core/ldes-client/tree-node-supplier/src/test/resources/features/member-supplier.feature
+++ b/ldi-core/ldes-client/tree-node-supplier/src/test/resources/features/member-supplier.feature
@@ -7,7 +7,6 @@ Feature: MemberSupplier
     And a StatePersistenceStrategy <statePersistenceStrategy>
     And The TreeNode is not processed: "http://localhost:10101/200-first-tree-node"
     When I create a Processor
-    Then Status "NOT_VISITED" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"
     When I create a MemberSupplier
     When I request one member from the MemberSupplier
     Then Status "IMMUTABLE" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"

--- a/ldi-core/ldes-client/tree-node-supplier/src/test/resources/features/restart-client.feature
+++ b/ldi-core/ldes-client/tree-node-supplier/src/test/resources/features/restart-client.feature
@@ -7,7 +7,6 @@ Feature: Restart MemberSupplier
     And a StatePersistenceStrategy SQLITE
     And The TreeNode is not processed: "http://localhost:10101/200-first-tree-node"
     When I create a Processor
-    Then Status "NOT_VISITED" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"
     When I create a MemberSupplier
     When I request one member from the MemberSupplier
     Then Status "IMMUTABLE" for TreeNodeRecord with identifier: "http://localhost:10101/200-first-tree-node"

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
@@ -8,7 +8,7 @@ import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.services.Requ
 import be.vlaanderen.informatievlaanderen.ldes.ldi.services.LdesPropertiesExtractor;
 import ldes.client.treenodesupplier.MemberSupplier;
 import ldes.client.treenodesupplier.TreeNodeProcessor;
-import ldes.client.treenodesupplier.domain.valueobject.LdesDescription;
+import ldes.client.treenodesupplier.domain.valueobject.LdesMetaData;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.SuppliedMember;
 import org.apache.jena.rdf.model.Model;
@@ -67,13 +67,13 @@ public class LdesClient extends AbstractProcessor {
 		String dataSourceUrl = LdesProcessorProperties.getDataSourceUrl(context);
 		Lang dataSourceFormat = LdesProcessorProperties.getDataSourceFormat(context);
 		final RequestExecutor requestExecutor = getRequestExecutorWithPossibleRetry(context);
-		LdesDescription ldesDescription = new LdesDescription(dataSourceUrl, dataSourceFormat);
-		TreeNodeProcessor treeNodeProcessor = new TreeNodeProcessor(ldesDescription,
+		LdesMetaData ldesMetaData = new LdesMetaData(dataSourceUrl, dataSourceFormat);
+		TreeNodeProcessor treeNodeProcessor = new TreeNodeProcessor(ldesMetaData,
 				StatePersistence.from(LdesProcessorProperties.getStatePersistenceStrategy(context)),
 				requestExecutor);
 		memberSupplier = new MemberSupplier(treeNodeProcessor, LdesProcessorProperties.stateKept(context));
 
-		determineLdesProperties(ldesDescription, requestExecutor, context);
+		determineLdesProperties(ldesMetaData, requestExecutor, context);
 
 		LOGGER.info("LDES extraction processor {} with base url {} (expected LDES source format: {})",
 				context.getName(), dataSourceUrl, dataSourceFormat);
@@ -97,12 +97,12 @@ public class LdesClient extends AbstractProcessor {
 		};
 	}
 
-	private void determineLdesProperties(LdesDescription ldesDescription, RequestExecutor requestExecutor,
-			ProcessContext context) {
+	private void determineLdesProperties(LdesMetaData ldesMetaData, RequestExecutor requestExecutor,
+                                         ProcessContext context) {
 		boolean timestampPath = streamTimestampPathProperty(context);
 		boolean versionOfPath = streamVersionOfProperty(context);
 		boolean shape = streamShapeProperty(context);
-		ldesProperties = new LdesPropertiesExtractor(requestExecutor).getLdesProperties(ldesDescription, timestampPath,
+		ldesProperties = new LdesPropertiesExtractor(requestExecutor).getLdesProperties(ldesMetaData, timestampPath,
 				versionOfPath, shape);
 	}
 

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
@@ -98,7 +98,7 @@ public class LdesClient extends AbstractProcessor {
 	}
 
 	private void determineLdesProperties(LdesMetaData ldesMetaData, RequestExecutor requestExecutor,
-                                         ProcessContext context) {
+			ProcessContext context) {
 		boolean timestampPath = streamTimestampPathProperty(context);
 		boolean versionOfPath = streamVersionOfProperty(context);
 		boolean shape = streamShapeProperty(context);

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClient.java
@@ -3,14 +3,12 @@ package be.vlaanderen.informatievlaanderen.ldes.ldi.processors;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.domain.valueobjects.LdesProperties;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.processors.config.LdesProcessorProperties;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.processors.services.FlowManager;
-import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.services.RequestExecutorFactory;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.RequestExecutor;
+import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.services.RequestExecutorFactory;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.services.LdesPropertiesExtractor;
-import ldes.client.treenodefetcher.TreeNodeFetcher;
 import ldes.client.treenodesupplier.MemberSupplier;
-import ldes.client.treenodesupplier.StartingTreeNodeSupplier;
 import ldes.client.treenodesupplier.TreeNodeProcessor;
-import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
+import ldes.client.treenodesupplier.domain.valueobject.LdesDescription;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.SuppliedMember;
 import org.apache.jena.rdf.model.Model;
@@ -69,14 +67,13 @@ public class LdesClient extends AbstractProcessor {
 		String dataSourceUrl = LdesProcessorProperties.getDataSourceUrl(context);
 		Lang dataSourceFormat = LdesProcessorProperties.getDataSourceFormat(context);
 		final RequestExecutor requestExecutor = getRequestExecutorWithPossibleRetry(context);
-		StartingTreeNode startingTreeNode = new StartingTreeNodeSupplier(requestExecutor).getStart(dataSourceUrl,
-				dataSourceFormat);
-		TreeNodeProcessor treeNodeProcessor = new TreeNodeProcessor(startingTreeNode,
+		LdesDescription ldesDescription = new LdesDescription(dataSourceUrl, dataSourceFormat);
+		TreeNodeProcessor treeNodeProcessor = new TreeNodeProcessor(ldesDescription,
 				StatePersistence.from(LdesProcessorProperties.getStatePersistenceStrategy(context)),
-				new TreeNodeFetcher(requestExecutor));
+				requestExecutor);
 		memberSupplier = new MemberSupplier(treeNodeProcessor, LdesProcessorProperties.stateKept(context));
 
-		determineLdesProperties(startingTreeNode, requestExecutor, context);
+		determineLdesProperties(ldesDescription, requestExecutor, context);
 
 		LOGGER.info("LDES extraction processor {} with base url {} (expected LDES source format: {})",
 				context.getName(), dataSourceUrl, dataSourceFormat);
@@ -100,12 +97,12 @@ public class LdesClient extends AbstractProcessor {
 		};
 	}
 
-	private void determineLdesProperties(StartingTreeNode startingTreeNode, RequestExecutor requestExecutor,
+	private void determineLdesProperties(LdesDescription ldesDescription, RequestExecutor requestExecutor,
 			ProcessContext context) {
 		boolean timestampPath = streamTimestampPathProperty(context);
 		boolean versionOfPath = streamVersionOfProperty(context);
 		boolean shape = streamShapeProperty(context);
-		ldesProperties = new LdesPropertiesExtractor(requestExecutor).getLdesProperties(startingTreeNode, timestampPath,
+		ldesProperties = new LdesPropertiesExtractor(requestExecutor).getLdesProperties(ldesDescription, timestampPath,
 				versionOfPath, shape);
 	}
 

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/services/LdesPropertiesExtractor.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/services/LdesPropertiesExtractor.java
@@ -36,8 +36,8 @@ public class LdesPropertiesExtractor {
 	}
 
 	public LdesProperties getLdesProperties(LdesMetaData ldesMetaData, boolean needTimestampPath,
-                                            boolean needVersionOfPath,
-                                            boolean needShape) {
+			boolean needVersionOfPath,
+			boolean needShape) {
 		StartingTreeNode startingTreeNode = new StartingTreeNodeSupplier(requestExecutor)
 				.getStart(ldesMetaData.getStartingNodeUrl(), ldesMetaData.getLang());
 		TreeNodeRequest request = startingTreeNode.createRequest(startingTreeNode.getStartingNodeUrl());

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/services/LdesPropertiesExtractor.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/services/LdesPropertiesExtractor.java
@@ -5,6 +5,8 @@ import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.Response;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.RequestExecutor;
 import ldes.client.treenodefetcher.domain.valueobjects.TreeNodeRequest;
+import ldes.client.treenodesupplier.StartingTreeNodeSupplier;
+import ldes.client.treenodesupplier.domain.valueobject.LdesDescription;
 import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.RDFParser;
@@ -33,9 +35,11 @@ public class LdesPropertiesExtractor {
 				.map(Resource::toString);
 	}
 
-	public LdesProperties getLdesProperties(StartingTreeNode startingTreeNode, boolean needTimestampPath,
+	public LdesProperties getLdesProperties(LdesDescription ldesDescription, boolean needTimestampPath,
 			boolean needVersionOfPath,
 			boolean needShape) {
+		StartingTreeNode startingTreeNode = new StartingTreeNodeSupplier(requestExecutor)
+				.getStart(ldesDescription.getStartingNodeUrl(), ldesDescription.getLang());
 		TreeNodeRequest request = startingTreeNode.createRequest(startingTreeNode.getStartingNodeUrl());
 		Request httpRequest = request.createRequest();
 		Response response = requestExecutor.execute(httpRequest);

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/services/LdesPropertiesExtractor.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/services/LdesPropertiesExtractor.java
@@ -6,7 +6,7 @@ import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.RequestExecutor;
 import ldes.client.treenodefetcher.domain.valueobjects.TreeNodeRequest;
 import ldes.client.treenodesupplier.StartingTreeNodeSupplier;
-import ldes.client.treenodesupplier.domain.valueobject.LdesDescription;
+import ldes.client.treenodesupplier.domain.valueobject.LdesMetaData;
 import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.RDFParser;
@@ -35,11 +35,11 @@ public class LdesPropertiesExtractor {
 				.map(Resource::toString);
 	}
 
-	public LdesProperties getLdesProperties(LdesDescription ldesDescription, boolean needTimestampPath,
-			boolean needVersionOfPath,
-			boolean needShape) {
+	public LdesProperties getLdesProperties(LdesMetaData ldesMetaData, boolean needTimestampPath,
+                                            boolean needVersionOfPath,
+                                            boolean needShape) {
 		StartingTreeNode startingTreeNode = new StartingTreeNodeSupplier(requestExecutor)
-				.getStart(ldesDescription.getStartingNodeUrl(), ldesDescription.getLang());
+				.getStart(ldesMetaData.getStartingNodeUrl(), ldesMetaData.getLang());
 		TreeNodeRequest request = startingTreeNode.createRequest(startingTreeNode.getStartingNodeUrl());
 		Request httpRequest = request.createRequest();
 		Response response = requestExecutor.execute(httpRequest);

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClientTest.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClientTest.java
@@ -83,7 +83,7 @@ class LdesClientTest {
 
 		testRunner.run(6);
 
-		WireMock.verify(2, getRequestedFor(urlEqualTo("/retry")));
+		WireMock.verify(3, getRequestedFor(urlEqualTo("/retry")));
 
 		List<MockFlowFile> dataFlowfiles = testRunner.getFlowFilesForRelationship(DATA_RELATIONSHIP);
 

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdesClientRunner.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdesClientRunner.java
@@ -5,7 +5,7 @@ import be.vlaanderen.informatievlaanderen.ldes.ldi.services.ComponentExecutor;
 import be.vlaanderen.informatievlaanderen.ldes.ldio.valueobjects.ComponentProperties;
 import ldes.client.treenodesupplier.MemberSupplier;
 import ldes.client.treenodesupplier.TreeNodeProcessor;
-import ldes.client.treenodesupplier.domain.valueobject.LdesDescription;
+import ldes.client.treenodesupplier.domain.valueobject.LdesMetaData;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistenceStrategy;
 import org.apache.jena.riot.Lang;
@@ -52,18 +52,18 @@ public class LdesClientRunner implements Runnable {
 		StatePersistenceStrategy state = properties.getOptionalProperty(LdioLdesClientProperties.STATE)
 				.flatMap(StatePersistenceStrategy::from)
 				.orElse(StatePersistenceStrategy.MEMORY);
-		LdesDescription ldesDescription = new LdesDescription(targetUrl,
+		LdesMetaData ldesMetaData = new LdesMetaData(targetUrl,
 				sourceFormat);
-		TreeNodeProcessor treeNodeProcessor = getTreeNodeProcessor(state, requestExecutor, ldesDescription);
+		TreeNodeProcessor treeNodeProcessor = getTreeNodeProcessor(state, requestExecutor, ldesMetaData);
 		boolean keepState = properties.getOptionalBoolean(LdioLdesClientProperties.KEEP_STATE).orElse(false);
 		return new MemberSupplier(treeNodeProcessor, keepState);
 	}
 
 	private TreeNodeProcessor getTreeNodeProcessor(StatePersistenceStrategy statePersistenceStrategy,
 			RequestExecutor requestExecutor,
-			LdesDescription ldesDescription) {
+			LdesMetaData ldesMetaData) {
 
-		return new TreeNodeProcessor(ldesDescription, StatePersistence.from(statePersistenceStrategy),
+		return new TreeNodeProcessor(ldesMetaData, StatePersistence.from(statePersistenceStrategy),
 				requestExecutor);
 	}
 

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdesClientRunner.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdesClientRunner.java
@@ -3,11 +3,9 @@ package be.vlaanderen.informatievlaanderen.ldes.ldio;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.RequestExecutor;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.services.ComponentExecutor;
 import be.vlaanderen.informatievlaanderen.ldes.ldio.valueobjects.ComponentProperties;
-import ldes.client.treenodefetcher.TreeNodeFetcher;
 import ldes.client.treenodesupplier.MemberSupplier;
-import ldes.client.treenodesupplier.StartingTreeNodeSupplier;
 import ldes.client.treenodesupplier.TreeNodeProcessor;
-import ldes.client.treenodesupplier.domain.valueobject.StartingTreeNode;
+import ldes.client.treenodesupplier.domain.valueobject.LdesDescription;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistence;
 import ldes.client.treenodesupplier.domain.valueobject.StatePersistenceStrategy;
 import org.apache.jena.riot.Lang;
@@ -54,19 +52,19 @@ public class LdesClientRunner implements Runnable {
 		StatePersistenceStrategy state = properties.getOptionalProperty(LdioLdesClientProperties.STATE)
 				.flatMap(StatePersistenceStrategy::from)
 				.orElse(StatePersistenceStrategy.MEMORY);
-		StartingTreeNode startingTreeNode = new StartingTreeNodeSupplier(requestExecutor).getStart(targetUrl,
+		LdesDescription ldesDescription = new LdesDescription(targetUrl,
 				sourceFormat);
-		TreeNodeProcessor treeNodeProcessor = getTreeNodeProcessor(state, requestExecutor, startingTreeNode);
+		TreeNodeProcessor treeNodeProcessor = getTreeNodeProcessor(state, requestExecutor, ldesDescription);
 		boolean keepState = properties.getOptionalBoolean(LdioLdesClientProperties.KEEP_STATE).orElse(false);
 		return new MemberSupplier(treeNodeProcessor, keepState);
 	}
 
 	private TreeNodeProcessor getTreeNodeProcessor(StatePersistenceStrategy statePersistenceStrategy,
 			RequestExecutor requestExecutor,
-			StartingTreeNode startingTreeNode) {
+			LdesDescription ldesDescription) {
 
-		return new TreeNodeProcessor(startingTreeNode, StatePersistence.from(statePersistenceStrategy),
-				new TreeNodeFetcher(requestExecutor));
+		return new TreeNodeProcessor(ldesDescription, StatePersistence.from(statePersistenceStrategy),
+				requestExecutor);
 	}
 
 	public void stopThread() {


### PR DESCRIPTION
Currently, the client wrappers would always determine the starting node (even if other tree nodes were already processed).
In this PR, logic to determine the starting node is included in the core library (TreeNodeProcessor) and is only executed once.