### PR TITLE
Fix: Client -> Folder may already exist

### DIFF
--- a/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/EntityManagerFactory.java
+++ b/ldi-core/ldes-client/tree-node-supplier/src/main/java/ldes/client/treenodesupplier/repository/sqlite/EntityManagerFactory.java
@@ -30,7 +30,7 @@ public class EntityManagerFactory {
 	public static synchronized EntityManagerFactory getInstance() {
 		if (instance == null) {
 			try {
-				Files.createDirectory(Paths.get(DATABASE_DIRECTORY));
+				Files.createDirectories(Paths.get(DATABASE_DIRECTORY));
 			} catch (IOException e) {
 				throw new CreateDirectoryFailedException(e);
 			}


### PR DESCRIPTION
Javadoc `createDirectories`:

Creates a directory by creating all nonexistent parent directories first. Unlike the createDirectory method, an exception is not thrown if the directory could not be created because it already exists.