### PR TITLE
Add run skipper to nifi processor

### DIFF
--- a/ldi-nifi/ldi-nifi-processors/archive-file-in/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/ArchiveFileInProcessor.java
+++ b/ldi-nifi/ldi-nifi-processors/archive-file-in/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/ArchiveFileInProcessor.java
@@ -13,6 +13,8 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -26,6 +28,8 @@ import static be.vlaanderen.informatievlaanderen.ldes.ldi.processors.services.Fl
 @Tags({ "ldes, vsds, archive, file" })
 @CapabilityDescription("Writes members to a file archive.")
 public class ArchiveFileInProcessor extends AbstractProcessor {
+
+	private final Logger log = LoggerFactory.getLogger(ArchiveFileInProcessor.class);
 
 	private ArchiveFileCrawler archiveFileCrawler;
 
@@ -56,8 +60,10 @@ public class ArchiveFileInProcessor extends AbstractProcessor {
 	@Override
 	public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
 		if (hasRun) {
+			log.info("Archive already read, the processor can be turned off.");
 			return;
 		}
+		log.info("Starting new read of full archive.");
 		readArchive(context, session);
 		hasRun = true;
 	}

--- a/ldi-nifi/ldi-nifi-processors/archive-file-in/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/ArchiveFileInProcessorTest.java
+++ b/ldi-nifi/ldi-nifi-processors/archive-file-in/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/ArchiveFileInProcessorTest.java
@@ -34,7 +34,7 @@ class ArchiveFileInProcessorTest {
 	void testProcessor() {
 		testRunner.setProperty(ARCHIVE_ROOT_DIR, archiveDir);
 
-		testRunner.run();
+		testRunner.run(5);
 
 		List<MockFlowFile> successFiles = testRunner.getFlowFilesForRelationship(SUCCESS);
 


### PR DESCRIPTION
Currently we only have a basic archive file in implementation which has no state and cannot be paused or restarted.
The files are read as one stream and triggered by one nifi trigger.

With this flag, we don't keep re-reading the entire archiving when starting the component. Resetting the component makes it possible to read the archive again.