### PR TITLE
Feat: Support model split in sparql construct

### DIFF
--- a/ldi-core/sparql-construct/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformer.java
+++ b/ldi-core/sparql-construct/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformer.java
@@ -48,7 +48,7 @@ public class SparqlConstructTransformer implements LdiTransformer {
 			return List.of(dataset.getDefaultModel());
 		}
 
-    }
+	}
 
 	private boolean hasMultipleModels(Dataset dataset) {
 		return dataset.listNames().hasNext();

--- a/ldi-core/sparql-construct/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformer.java
+++ b/ldi-core/sparql-construct/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformer.java
@@ -1,14 +1,16 @@
 package be.vlaanderen.informatievlaanderen.ldes.ldi;
 
 import be.vlaanderen.informatievlaanderen.ldes.ldi.types.LdiTransformer;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 public class SparqlConstructTransformer implements LdiTransformer {
+
 	private final Query query;
 	private final boolean includeOriginal;
 
@@ -19,12 +21,53 @@ public class SparqlConstructTransformer implements LdiTransformer {
 
 	@Override
 	public List<Model> apply(Model linkedDataModel) {
-		try (QueryExecution qexec = QueryExecutionFactory.create(query, linkedDataModel)) {
-			Model resultModel = qexec.execConstruct();
-			if (includeOriginal) {
-				resultModel.add(linkedDataModel);
-			}
-			return List.of(resultModel);
+		final Dataset dataset = queryDataset(linkedDataModel);
+		final List<Model> result = extractModelsFromDataset(dataset);
+		handleIncludeOriginal(result, linkedDataModel);
+		return result;
+	}
+
+	private Dataset queryDataset(Model linkedDataModel) {
+		final var dataset = DatasetFactory.create(linkedDataModel);
+		try (QueryExecution qexec = QueryExecutionFactory.create(query, dataset)) {
+			return qexec.execConstructDataset();
 		}
 	}
+
+	private void handleIncludeOriginal(List<Model> result, Model linkedDataModel) {
+		if (includeOriginal && result.size() == 1) {
+			result.get(0).add(linkedDataModel);
+		}
+	}
+
+	private List<Model> extractModelsFromDataset(Dataset dataset) {
+
+		if (hasMultipleModels(dataset)) {
+			return splitDataset(dataset);
+		} else {
+			return List.of(dataset.getDefaultModel());
+		}
+
+    }
+
+	private boolean hasMultipleModels(Dataset dataset) {
+		return dataset.listNames().hasNext();
+	}
+
+	private List<Model> splitDataset(Dataset dataset) {
+		List<Model> result = new ArrayList<>();
+		Iterator<Resource> it = dataset.listModelNames();
+		while (it.hasNext()) {
+			Model namedModel = dataset.getNamedModel(it.next());
+			namedModel.add(dataset.getDefaultModel());
+			result.add(namedModel);
+		}
+
+		if (result.isEmpty()) {
+			result.add(dataset.getDefaultModel());
+		}
+
+		return result;
+	}
+
 }

--- a/ldi-core/sparql-construct/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformerTest.java
+++ b/ldi-core/sparql-construct/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformerTest.java
@@ -1,15 +1,21 @@
 package be.vlaanderen.informatievlaanderen.ldes.ldi;
 
-import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.riot.*;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SparqlConstructTransformerTest {
 
@@ -57,6 +63,43 @@ class SparqlConstructTransformerTest {
 
 		assertTrue(models.get(0).contains(transformedData));
 		assertTrue(models.get(0).contains(originalData));
-
 	}
+
+	@Test
+	void shouldSplitModels_whenQueryContainsGraph_AndHasNoDefaultModelStatements() throws IOException {
+		Model inputModel = RDFParser.source("crowdscan/input.ttl").toModel();
+		String constructQuery = Files.readString(Path.of("./src/test/resources/crowdscan/query.rq"));
+		SparqlConstructTransformer sparqlConstructTransformer = new SparqlConstructTransformer(
+				QueryFactory.create(constructQuery), false);
+
+		List<Model> result = sparqlConstructTransformer.apply(inputModel);
+
+		assertEquals(3, result.size());
+		assertModels(
+				List.of("crowdscan/observation1.ttl", "crowdscan/observation2.ttl", "crowdscan/observation3.ttl"),
+				result);
+	}
+
+	@Test
+	void shouldSplitModels_whenQueryContainsGraph_AndHasDefaultModelStatements() throws IOException {
+		// TODO TVB: 06/09/23 traffic impl
+	}
+
+	private void assertModels(List<String> expectedModelPaths, Collection<Model> result) {
+		Set<Model> expectedModels = expectedModelPaths
+				.stream()
+				.map(RDFParser::source)
+				.map(RDFParserBuilder::toModel)
+				.collect(Collectors.toSet());
+
+		result.forEach(
+				actualResult -> {
+					System.out.println(RDFWriter.source(actualResult).lang(Lang.TURTLE).asString());
+					expectedModels
+							.removeIf(expectedResult -> expectedResult.isIsomorphicWith(actualResult));
+				});
+
+		assertTrue(expectedModels.isEmpty());
+	}
+
 }

--- a/ldi-core/sparql-construct/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformerTest.java
+++ b/ldi-core/sparql-construct/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/SparqlConstructTransformerTest.java
@@ -81,8 +81,40 @@ class SparqlConstructTransformerTest {
 	}
 
 	@Test
+	void shouldNotSplitModels_whenQueryContainsNoGraph_AndHasOnlyDefaultModelStatements() throws IOException {
+		Model inputModel = RDFParser.source("crowdscan/input.ttl").toModel();
+		String constructQuery = Files.readString(Path.of("./src/test/resources/crowdscan/no-graph-query.rq"));
+		SparqlConstructTransformer sparqlConstructTransformer = new SparqlConstructTransformer(
+				QueryFactory.create(constructQuery), false);
+
+		List<Model> result = sparqlConstructTransformer.apply(inputModel);
+
+		assertEquals(1, result.size());
+		Model expectedResult = RDFParser.source("crowdscan/no-graph-observations.ttl").toModel();
+		assertTrue(expectedResult.isIsomorphicWith(result.get(0)));
+	}
+
+	@Test
 	void shouldSplitModels_whenQueryContainsGraph_AndHasDefaultModelStatements() throws IOException {
-		// TODO TVB: 06/09/23 traffic impl
+		Model inputModel = RDFParser.source("traffic/input.ttl").toModel();
+		String constructQuery = Files.readString(Path.of("./src/test/resources/traffic/query.rq"));
+		SparqlConstructTransformer sparqlConstructTransformer = new SparqlConstructTransformer(
+				QueryFactory.create(constructQuery), false);
+
+		List<Model> result = sparqlConstructTransformer.apply(inputModel);
+
+		assertEquals(10, result.size());
+		assertModels(List.of(
+				"traffic/measure1.ttl",
+				"traffic/measure2.ttl",
+				"traffic/measure3.ttl",
+				"traffic/measure4.ttl",
+				"traffic/measure5.ttl",
+				"traffic/measure6.ttl",
+				"traffic/measure7.ttl",
+				"traffic/measure8.ttl",
+				"traffic/measure9.ttl",
+				"traffic/measure10.ttl"), result);
 	}
 
 	private void assertModels(List<String> expectedModelPaths, Collection<Model> result) {

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/input.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/input.ttl
@@ -1,0 +1,16 @@
+@prefix cs: <http://www.crowdscan.be/ns/count#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+  cs:header [
+    cs:environment "beacon"^^xsd:string ;
+    cs:last_updated "2023-09-05T07:08:53.479483Z"^^xsd:string ;
+    cs:time "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+    cs:timedelta "15"^^xsd:int
+  ] ;
+  cs:payload [ cs:regions (
+     2.236581e-1
+     0
+     2.741105e-1
+     5.051886e-1
+   ) ] .

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/no-graph-observations.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/no-graph-observations.ttl
@@ -1,0 +1,29 @@
+@prefix cs-count: <http://www.crowdscan.be/ns/count#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema:   <http://schema.org/> .
+@prefix time:     <http://www.w3.org/2006/time#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.crowdscan.be/id/observation/beacon/1>
+        rdf:type              cs-count:Observation ;
+        cs-count:environment  "beacon" ;
+        cs-count:region       1 ;
+        cs-count:time         "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+        cs-count:timedelta    "-PT15M"^^xsd:duration ;
+        cs-count:value        0 .
+
+<http://www.crowdscan.be/id/observation/beacon/2>
+        rdf:type              cs-count:Observation ;
+        cs-count:environment  "beacon" ;
+        cs-count:region       2 ;
+        cs-count:time         "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+        cs-count:timedelta    "-PT15M"^^xsd:duration ;
+        cs-count:value        2.741105e-1 .
+
+<http://www.crowdscan.be/id/observation/beacon/3>
+        rdf:type              cs-count:Observation ;
+        cs-count:environment  "beacon" ;
+        cs-count:region       3 ;
+        cs-count:time         "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+        cs-count:timedelta    "-PT15M"^^xsd:duration ;
+        cs-count:value        5.051886e-1 .

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/no-graph-query.rq
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/no-graph-query.rq
@@ -1,0 +1,32 @@
+PREFIX rdf:          <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd:          <http://www.w3.org/2001/XMLSchema#>
+PREFIX schema:       <http://schema.org/>
+PREFIX time:         <http://www.w3.org/2006/time#>
+PREFIX cs-count:     <http://www.crowdscan.be/ns/count#>
+
+CONSTRUCT {
+    ?observation rdf:type cs-count:Observation .
+    ?observation cs-count:time ?time .
+    ?observation cs-count:value ?value .
+    ?observation cs-count:environment ?environment .
+    ?observation cs-count:timedelta ?delta .
+    ?observation cs-count:region ?zone .
+} WHERE {
+    ?header cs-count:environment ?environment .
+    ?header cs-count:time ?time .
+    ?header cs-count:timedelta ?timedelta .
+    bind(strdt(concat("-PT", str(?timedelta), "M"), xsd:duration) as ?delta) .
+
+    ?payload cs-count:payload ?regions .
+    {
+      SELECT ?value (count(?mid) as ?zone)
+      WHERE
+      {
+        ?regions rdf:rest* ?mid .
+        ?mid rdf:rest ?node .
+        ?node rdf:first ?value .
+      }
+      GROUP BY ?node ?value
+    }
+    bind(uri(concat("http://www.crowdscan.be/id/observation/", ?environment, "/", str(?zone))) as ?observation) .
+  }

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/observation1.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/observation1.ttl
@@ -1,0 +1,13 @@
+@prefix cs-count: <http://www.crowdscan.be/ns/count#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema:   <http://schema.org/> .
+@prefix time:     <http://www.w3.org/2006/time#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.crowdscan.be/id/observation/beacon/1>
+        rdf:type              cs-count:Observation ;
+        cs-count:environment  "beacon" ;
+        cs-count:region       1 ;
+        cs-count:time         "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+        cs-count:timedelta    "-PT15M"^^xsd:duration ;
+        cs-count:value        0 .

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/observation2.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/observation2.ttl
@@ -1,0 +1,13 @@
+@prefix cs-count: <http://www.crowdscan.be/ns/count#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema:   <http://schema.org/> .
+@prefix time:     <http://www.w3.org/2006/time#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.crowdscan.be/id/observation/beacon/2>
+        rdf:type              cs-count:Observation ;
+        cs-count:environment  "beacon" ;
+        cs-count:region       2 ;
+        cs-count:time         "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+        cs-count:timedelta    "-PT15M"^^xsd:duration ;
+        cs-count:value        2.741105e-1 .

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/observation3.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/observation3.ttl
@@ -1,0 +1,13 @@
+@prefix cs-count: <http://www.crowdscan.be/ns/count#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema:   <http://schema.org/> .
+@prefix time:     <http://www.w3.org/2006/time#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.crowdscan.be/id/observation/beacon/3>
+        rdf:type              cs-count:Observation ;
+        cs-count:environment  "beacon" ;
+        cs-count:region       3 ;
+        cs-count:time         "2023-09-05T07:08:53.479483Z"^^xsd:DateTime ;
+        cs-count:timedelta    "-PT15M"^^xsd:duration ;
+        cs-count:value        5.051886e-1 .

--- a/ldi-core/sparql-construct/src/test/resources/crowdscan/query.rq
+++ b/ldi-core/sparql-construct/src/test/resources/crowdscan/query.rq
@@ -1,0 +1,34 @@
+PREFIX rdf:          <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd:          <http://www.w3.org/2001/XMLSchema#>
+PREFIX schema:       <http://schema.org/>
+PREFIX time:         <http://www.w3.org/2006/time#>
+PREFIX cs-count:     <http://www.crowdscan.be/ns/count#>
+
+CONSTRUCT {
+  GRAPH ?observation {
+    ?observation rdf:type cs-count:Observation .
+    ?observation cs-count:time ?time .
+    ?observation cs-count:value ?value .
+    ?observation cs-count:environment ?environment .
+    ?observation cs-count:timedelta ?delta .
+    ?observation cs-count:region ?zone .
+  }
+} WHERE {
+    ?header cs-count:environment ?environment .
+    ?header cs-count:time ?time .
+    ?header cs-count:timedelta ?timedelta .
+    bind(strdt(concat("-PT", str(?timedelta), "M"), xsd:duration) as ?delta) .
+
+    ?payload cs-count:payload ?regions .
+    {
+      SELECT ?value (count(?mid) as ?zone)
+      WHERE
+      {
+        ?regions rdf:rest* ?mid .
+        ?mid rdf:rest ?node .
+        ?node rdf:first ?value .
+      }
+      GROUP BY ?node ?value
+    }
+    bind(uri(concat("http://www.crowdscan.be/id/observation/", ?environment, "/", str(?zone))) as ?observation) .
+  }

--- a/ldi-core/sparql-construct/src/test/resources/traffic/input.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/input.ttl
@@ -1,227 +1,53 @@
-@prefix dcterms:        <http://purl.org/dc/terms/> .
-@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
-@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
-@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
-@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
-@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
-@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
-@prefix prov:           <http://www.w3.org/ns/prov#> .
-@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix sosa:           <http://www.w3.org/ns/sosa/> .
-@prefix ssn:            <http://www.w3.org/ns/ssn/> .
-@prefix time:           <http://www.w3.org/2006/time#> .
-@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+@prefix vm: <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/4>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "49"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/5>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "5"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "5"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/3>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
-        rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#sensor>
-        rdf:type        sosa:Sensor ;
-        dcterms:type    "Verkeersmeting"^^dv-vm:Meetinstrumenttype ;
-        ssn:implements  [ rdf:type      sosa:Procedure ;
-                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
-                        ] ;
-        ssn:implements  [ rdf:type      sosa:Procedure ;
-                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
-                        ] ;
-        ssn:implements  [ rdf:type      sosa:Procedure ;
-                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
-                        ] ;
-        ssn:implements  [ rdf:type      sosa:Procedure ;
-                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
-                        ] ;
-        ssn:implements  [ rdf:type      sosa:Procedure ;
-                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
-                        ] .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
-        rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/2>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "68"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/4>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "1"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "1"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
-        rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/3>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "0"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/1>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/2>
-        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
-        iso19156-co:OM_CountObservation.result
-                "3"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "3"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245>
-        rdf:type              dv-vm:Verkeersmetingverzameling ;
-        prov:generatedAtTime  "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:fenomeentijd    <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:heeftLid        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/2> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/5> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/1> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/4> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/3> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/5> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/2> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/3> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/1> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/4> ;
-        dv-vm:uitgevoerdMet   <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#sensor> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/1>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "0"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/5>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "51"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
+<http://www.wegenenverkeer.be/id/verkeersmetingen/meting/29>
+  vm:unieke_id "29"^^xsd:int ;
+  dc:modified "2019-12-05T10:26:49+01:00"^^xsd:dateTime ;
+  vm:tijd_laatst_gewijzigd "2023-08-04T15:29:16+02:00"^^xsd:dateTime ;
+  a vm:Meting ;
+  vm:tijd_waarneming "2023-08-04T14:28:00+01:00"^^xsd:dateTime ;
+  dc:issued "2023-08-04T15:29:40.997+02:00"^^xsd:dateTime ;
+  vm:meetData [
+    vm:klasse_id "2"^^xsd:int ;
+    vm:voertuigsnelheid_harmonisch "252"^^xsd:int ;
+    vm:verkeersintensiteit "0"^^xsd:int ;
+    a vm:MeetData ;
+    vm:voertuigsnelheid_rekenkundig "0"^^xsd:int
+  ], [
+    vm:klasse_id "4"^^xsd:int ;
+    vm:voertuigsnelheid_harmonisch "252"^^xsd:int ;
+    vm:verkeersintensiteit "0"^^xsd:int ;
+    a vm:MeetData ;
+    vm:voertuigsnelheid_rekenkundig "0"^^xsd:int
+  ], [
+    vm:klasse_id "5"^^xsd:int ;
+    vm:voertuigsnelheid_harmonisch "252"^^xsd:int ;
+    vm:verkeersintensiteit "0"^^xsd:int ;
+    a vm:MeetData ;
+    vm:voertuigsnelheid_rekenkundig "0"^^xsd:int
+  ], [
+    vm:klasse_id "1"^^xsd:int ;
+    vm:voertuigsnelheid_harmonisch "252"^^xsd:int ;
+    vm:verkeersintensiteit "0"^^xsd:int ;
+    a vm:MeetData ;
+    vm:voertuigsnelheid_rekenkundig "0"^^xsd:int
+  ], [
+    vm:klasse_id "3"^^xsd:int ;
+    vm:voertuigsnelheid_harmonisch "252"^^xsd:int ;
+    vm:verkeersintensiteit "0"^^xsd:int ;
+    a vm:MeetData ;
+    vm:voertuigsnelheid_rekenkundig "0"^^xsd:int
+  ] ;
+  vm:beschikbaar "1"^^xsd:int ;
+  vm:actueel_publicatie "0"^^xsd:int ;
+  vm:lve_nr "55"^^xsd:int ;
+  vm:defect "0"^^xsd:int ;
+  vm:rekenData [
+    a vm:RekenData ;
+    vm:beschikbaarheidsgraad "100"^^xsd:int ;
+    vm:bezettingsgraad "0"^^xsd:int ;
+    vm:onrustigheid "0"^^xsd:int
+  ] ;
+  vm:geldig "0"^^xsd:int .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/input.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/input.ttl
@@ -1,0 +1,227 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/4>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "49"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/5>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "5"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "5"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/3>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#sensor>
+        rdf:type        sosa:Sensor ;
+        dcterms:type    "Verkeersmeting"^^dv-vm:Meetinstrumenttype ;
+        ssn:implements  [ rdf:type      sosa:Procedure ;
+                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
+                        ] ;
+        ssn:implements  [ rdf:type      sosa:Procedure ;
+                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
+                        ] ;
+        ssn:implements  [ rdf:type      sosa:Procedure ;
+                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
+                        ] ;
+        ssn:implements  [ rdf:type      sosa:Procedure ;
+                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
+                        ] ;
+        ssn:implements  [ rdf:type      sosa:Procedure ;
+                          dcterms:type  "???"^^dv-vm:Observatieproceduretype
+                        ] .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/2>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "68"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/4>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "1"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "1"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/3>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/1>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/2>
+        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
+        iso19156-co:OM_CountObservation.result
+                "3"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "3"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245>
+        rdf:type              dv-vm:Verkeersmetingverzameling ;
+        prov:generatedAtTime  "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:fenomeentijd    <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:heeftLid        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/2> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/5> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/1> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/4> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/3> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/5> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/2> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/3> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/1> , <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/4> ;
+        dv-vm:uitgevoerdMet   <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#sensor> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/1>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/5>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "51"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure1.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure1.ttl
@@ -1,0 +1,41 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/4>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "49"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure1.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure1.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,32 +11,33 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/4>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/snelheid/4>
         rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "49"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        prov:generatedAtTime           "2023-08-04T14:28:00+01:00"^^xsd:dateTime ;
         dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
-        rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
 <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/4>
         rdf:type            dv-vm:Verkeerskenmerk ;
         dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
         dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure10.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure10.ttl
@@ -1,0 +1,41 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/5>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "51"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure10.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure10.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,32 +11,38 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/5>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "51"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2>
         rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/aantal/2>
+        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure2.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure2.ttl
@@ -1,0 +1,46 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/5>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "5"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "5"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure2.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure2.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,37 +11,33 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/5>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "5"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "5"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/snelheid/5>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        prov:generatedAtTime           "2023-08-04T14:28:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/5>
         rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
         dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure3.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure3.ttl
@@ -1,0 +1,41 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/3>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure3.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure3.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,32 +11,33 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/3>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/snelheid/2>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        prov:generatedAtTime           "2023-08-04T14:28:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2>
         rdf:type            dv-vm:Verkeerskenmerk ;
         dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
+        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
-        rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure4.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure4.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,32 +11,33 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/2>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/snelheid/3>
         rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "68"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        prov:generatedAtTime           "2023-08-04T14:28:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/3>
         rdf:type            dv-vm:Verkeerskenmerk ;
         dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
+        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure4.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure4.ttl
@@ -1,0 +1,41 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/2>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "68"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/2>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure5.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure5.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,37 +11,33 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/4>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "1"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "1"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/snelheid/1>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        prov:generatedAtTime           "2023-08-04T14:28:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1>
         rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure5.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure5.ttl
@@ -1,0 +1,46 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/4>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "1"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "1"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure6.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure6.ttl
@@ -1,0 +1,46 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/3>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure6.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure6.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,37 +11,38 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/3>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "4"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/aantal/4>
+        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
         iso19156-co:OM_CountObservation.result
                 "0"^^xsd:int ;
         iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
         iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
         iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/4> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure7.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure7.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,32 +11,38 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/1>
-        rdf:type                       dv-vm:Verkeersmeting ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/aantal/3>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
         iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1>
-        rdf:type            dv-vm:Verkeerskenmerk ;
-        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/3>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "3"^^dv-vm:Voertuigtype .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure7.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure7.ttl
@@ -1,0 +1,41 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/snelheid/1>
+        rdf:type                       dv-vm:Verkeersmeting ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        prov:generatedAtTime           "2023-08-31T06:16:00+01:00"^^xsd:dateTime ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/1>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "snelheid"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure8.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure8.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,38 +11,38 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/2>
-        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
-        iso19156-co:OM_CountObservation.result
-                "3"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "3"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5>
         rdf:type            dv-vm:Verkeerskenmerk ;
         dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
-        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
+        dv-vm:voertuigType  "5"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
-        rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/aantal/5>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/5> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure8.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure8.ttl
@@ -1,0 +1,47 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/2>
+        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
+        iso19156-co:OM_CountObservation.result
+                "3"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "3"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/2>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "2"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure9.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure9.ttl
@@ -1,0 +1,46 @@
+@prefix dcterms:        <http://purl.org/dc/terms/> .
+@prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
+@prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
+@prefix iso19156-co:    <http://def.isotc211.org/iso19156/2011/CountObservation#> .
+@prefix iso19156-om-co: <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.> .
+@prefix iso19156-om-ob: <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.> .
+@prefix miv:            <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa:           <http://www.w3.org/ns/sosa/> .
+@prefix ssn:            <http://www.w3.org/ns/ssn/> .
+@prefix time:           <http://www.w3.org/2006/time#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/1>
+        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1>
+        rdf:type            dv-vm:Verkeerskenmerk ;
+        dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
+        dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+        rdf:type           time:ProperInterval ;
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+        rdf:type                 time:Instant ;
+        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/measure9.ttl
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/measure9.ttl
@@ -1,3 +1,4 @@
+@prefix dc:             <http://purl.org/dc/terms/> .
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix dv-vm:          <https://data.vlaanderen.be/ns/verkeersmetingen#> .
 @prefix iso19156:       <http://def.isotc211.org/iso19156/2011/> .
@@ -10,37 +11,38 @@
 @prefix sosa:           <http://www.w3.org/ns/sosa/> .
 @prefix ssn:            <http://www.w3.org/ns/ssn/> .
 @prefix time:           <http://www.w3.org/2006/time#> .
+@prefix vm:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
-
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245/aantal/1>
-        rdf:type                       iso19156-co:OM_CountObservation , dv-vm:Verkeersmeting ;
-        iso19156-co:OM_CountObservation.result
-                "0"^^xsd:int ;
-        iso19156-om-ob:featureOfInterest
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        iso19156-om-ob:observedProperty
-                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
-        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00> ;
-        iso19156-om-ob:result          "0"^^xsd:int ;
-        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
-        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245#rijstrook> ;
-        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/4245> .
 
 <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1>
         rdf:type            dv-vm:Verkeerskenmerk ;
         dv-vm:type          "aantal"^^dv-vm:Verkeerskenmerktype ;
         dv-vm:voertuigType  "1"^^dv-vm:Voertuigtype .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00-2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29/aantal/1>
+        rdf:type                       dv-vm:Verkeersmeting , iso19156-co:OM_CountObservation ;
+        iso19156-co:OM_CountObservation.result
+                "0"^^xsd:int ;
+        iso19156-om-ob:featureOfInterest
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        iso19156-om-ob:observedProperty
+                <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
+        iso19156-om-ob:phenomenonTime  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00> ;
+        iso19156-om-ob:result          "0"^^xsd:int ;
+        iso19156-om-ob:resultTime      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        dv-vm:geobserveerdKenmerk      <https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/1> ;
+        dv-vm:geobserveerdObject       <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29#rijstrook> ;
+        dv-vm:verkeersmeetpunt         <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/29> .
+
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00-2023-08-04T15:29:16+02:00>
         rdf:type           time:ProperInterval ;
-        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00> ;
-        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00> .
+        time:hasBeginning  <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00> ;
+        time:hasEnd        <https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00> .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T06:16:00+01:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T14:28:00+01:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T06:16:00+01:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T14:28:00+01:00"^^xsd:dateTime .
 
-<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/4245#2023-08-31T07:17:21+02:00>
+<https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/29#2023-08-04T15:29:16+02:00>
         rdf:type                 time:Instant ;
-        time:inXSDDateTimeStamp  "2023-08-31T07:17:21+02:00"^^xsd:dateTime .
+        time:inXSDDateTimeStamp  "2023-08-04T15:29:16+02:00"^^xsd:dateTime .

--- a/ldi-core/sparql-construct/src/test/resources/traffic/query.rq
+++ b/ldi-core/sparql-construct/src/test/resources/traffic/query.rq
@@ -1,0 +1,95 @@
+PREFIX rdf:             <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX dcterms:         <http://purl.org/dc/terms/>
+PREFIX miv:             <http://www.wegenenverkeer.be/ns/verkeersmetingen#>
+PREFIX xsd:             <http://www.w3.org/2001/XMLSchema#>
+
+PREFIX dv-vm:           <https://data.vlaanderen.be/ns/verkeersmetingen#>
+PREFIX iso19156:        <http://def.isotc211.org/iso19156/2011/>
+PREFIX iso19156-co:     <http://def.isotc211.org/iso19156/2011/CountObservation#>
+PREFIX iso19156-om-co:  <http://def.isotc211.org/iso19156/2011/CountObservation#OM_CountObservation.>
+PREFIX iso19156-om-ob:  <http://def.isotc211.org/iso19156/2011/Observation#OM_Observation.>
+PREFIX time:            <http://www.w3.org/2006/time#>
+PREFIX sosa:            <http://www.w3.org/ns/sosa/>
+PREFIX ssn:             <http://www.w3.org/ns/ssn/>
+PREFIX prov:            <http://www.w3.org/ns/prov#>
+
+CONSTRUCT {
+  {
+    ?create_id a time:Instant ; time:inXSDDateTimeStamp ?tijd_waarneming  .
+    ?change_id a time:Instant ; time:inXSDDateTimeStamp ?tijd_laatst_gewijzigd  .
+    ?interval_id a time:ProperInterval ; time:hasBeginning ?create_id ; time:hasEnd ?change_id .
+  }
+
+  GRAPH ?count_id {
+    ?aantal_id a dv-vm:Verkeerskenmerk ; dv-vm:type "aantal"^^dv-vm:Verkeerskenmerktype ; dv-vm:voertuigType ?klasse .
+
+    ?count_id a dv-vm:Verkeersmeting, iso19156-co:OM_CountObservation ;
+      iso19156-om-ob:phenomenonTime ?interval_id ;
+      dv-vm:geobserveerdKenmerk ?aantal_id ; iso19156-om-ob:observedProperty ?aantal_id ;
+      dv-vm:geobserveerdObject ?rijstrook_id ; iso19156-om-ob:featureOfInterest ?rijstrook_id ;
+      iso19156-om-ob:resultTime ?create_id ;
+      iso19156-om-ob:result ?verkeersintensiteit ; iso19156-om-co:result ?verkeersintensiteit ;
+      dv-vm:verkeersmeetpunt ?meetpunt_id .
+  }
+
+  GRAPH ?speed_id {
+    ?snelheid_id a dv-vm:Verkeerskenmerk ; dv-vm:type "snelheid"^^dv-vm:Verkeerskenmerktype ; dv-vm:voertuigType ?klasse .
+
+    ?speed_id a dv-vm:Verkeersmeting ;
+      prov:generatedAtTime ?tijd_waarneming ;
+      iso19156-om-ob:phenomenonTime ?interval_id ;
+      dv-vm:geobserveerdKenmerk ?snelheid_id ;
+      dv-vm:geobserveerdObject ?rijstrook_id ;
+      iso19156-om-ob:resultTime ?create_id ;
+      iso19156-om-ob:result ?voertuigsnelheid_rekenkundig ;
+      dv-vm:verkeersmeetpunt ?meetpunt_id .
+  }
+#  ?collection_id a dv-vm:Verkeersmetingverzameling ;
+#    prov:generatedAtTime ?tijd_waarneming ;
+#    dv-vm:fenomeentijd ?create_id ;
+#    dv-vm:uitgevoerdMet ?sensor_id .
+#
+#  ?sensor_id a sosa:Sensor ;
+#    dcterms:type "Verkeersmeting"^^dv-vm:Meetinstrumenttype ;
+#    ssn:implements [ a sosa:Procedure ; dcterms:type "???"^^dv-vm:Observatieproceduretype ] .
+#
+#  ?collection_id dv-vm:heeftLid ?count_id .
+#  ?collection_id dv-vm:heeftLid ?speed_id .
+}
+WHERE {
+    ?sub rdf:type <http://www.wegenenverkeer.be/ns/verkeersmetingen#Meting> .
+    ?sub miv:unieke_id ?unieke_id .
+    ?sub miv:tijd_waarneming ?tijd_waarneming .
+    ?sub miv:tijd_laatst_gewijzigd ?tijd_laatst_gewijzigd .
+    ?sub miv:meetData ?meetData .
+    ?meetData miv:klasse_id ?klasse_id .
+    ?meetData miv:verkeersintensiteit ?verkeersintensiteit .
+    ?meetData miv:voertuigsnelheid_rekenkundig ?voertuigsnelheid_rekenkundig .
+
+    bind(concat("https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeting/", str(?unieke_id)) as ?collection) .
+#    bind(uri(?collection) as ?collection_id) .
+
+    bind(concat(?collection, "#", str(?tijd_waarneming)) as ?create) .
+    bind(uri(?create) as ?create_id) .
+
+    bind(concat(?collection, "#", str(?tijd_laatst_gewijzigd)) as ?change) .
+    bind(uri(?change) as ?change_id) .
+
+    bind(concat(?create, "-", str(?tijd_laatst_gewijzigd)) as ?interval) .
+    bind(uri(?interval) as ?interval_id) .
+
+    bind(uri(concat("https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/aantal/", str(?klasse_id))) as ?aantal_id) .
+    bind(strdt(str(?klasse_id), dv-vm:Voertuigtype) as ?klasse) .
+    bind(uri(concat("https://data.vlaanderen.be/id/verkeersmetingen/Verkeerskenmerk/snelheid/", str(?klasse_id))) as ?snelheid_id) .
+
+    bind(uri(concat(?collection, "/aantal/", str(?klasse_id))) as ?count_id) .
+    bind(uri(concat(?collection, "/snelheid/", str(?klasse_id))) as ?speed_id) .
+
+    bind(concat("https://data.vlaanderen.be/id/verkeersmetingen/Verkeersmeetpunt/", str(?unieke_id)) as ?meetpunt) .
+    bind(uri(?meetpunt) as ?meetpunt_id) .
+    bind(uri(concat(?meetpunt, "#rijstrook")) as ?rijstrook_id) .
+
+#    bind(concat(?collection, "#sensor") as ?sensor) .
+#    bind(uri(?sensor) as ?sensor_id) .
+
+}


### PR DESCRIPTION
Extends the sparql construct transformer so that graphs can be added in the query, which can be used to split a model into multiple named models. The change is fully backwards compatible.