### PR TITLE
docs: [ci skip] Update LDES Client Connector menu name

### DIFF
--- a/docs/_ldio/ldio-inputs/ldio-ldes-client-connector.md
+++ b/docs/_ldio/ldio-inputs/ldio-ldes-client-connector.md
@@ -1,7 +1,7 @@
 ---
   layout: default
   parent: LDIO Inputs
-  title: LDES Client
+  title: LDES Client with Connector
 ---
 
 # LDIO Ldes Client Connector


### PR DESCRIPTION
Updated the menu name to prevent 2 times "LDES Client" is shown