### PR TITLE
fix: broken pipeline status event handler

### DIFF
--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/collection/LdioLdesClientConnectorApiCollection.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/collection/LdioLdesClientConnectorApiCollection.java
@@ -1,0 +1,13 @@
+package be.vlaanderen.informatievlaanderen.ldes.ldio.collection;
+
+import be.vlaanderen.informatievlaanderen.ldes.ldio.LdioLdesClientConnectorApi;
+
+import java.util.Optional;
+
+public interface LdioLdesClientConnectorApiCollection {
+	Optional<LdioLdesClientConnectorApi> get(String pipeline);
+
+	void add(String pipeline, LdioLdesClientConnectorApi ldioLdesClientConnectorApi);
+
+	LdioLdesClientConnectorApi remove(String pipeline);
+}

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/collection/LdioLdesClientConnectorApiCollectionImpl.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/collection/LdioLdesClientConnectorApiCollectionImpl.java
@@ -1,0 +1,28 @@
+package be.vlaanderen.informatievlaanderen.ldes.ldio.collection;
+
+import be.vlaanderen.informatievlaanderen.ldes.ldio.LdioLdesClientConnectorApi;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class LdioLdesClientConnectorApiCollectionImpl implements LdioLdesClientConnectorApiCollection {
+	private final Map<String, LdioLdesClientConnectorApi> clientConnectorApis = new HashMap<>();
+
+	@Override
+	public Optional<LdioLdesClientConnectorApi> get(String pipeline) {
+		return Optional.ofNullable(clientConnectorApis.get(pipeline));
+	}
+
+	@Override
+	public void add(String pipeline, LdioLdesClientConnectorApi ldioLdesClientConnectorApi) {
+		clientConnectorApis.put(pipeline, ldioLdesClientConnectorApi);
+	}
+
+	@Override
+	public LdioLdesClientConnectorApi remove(String pipeline) {
+		return clientConnectorApis.remove(pipeline);
+	}
+}

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorTest.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = LdioLdesClientConnectorApiController.class)
+@ComponentScan(basePackages = "be.vlaanderen.informatievlaanderen.ldes.ldio.collection")
 @AutoConfigureMockMvc
 class LdioLdesClientConnectorTest {
 
@@ -32,13 +34,12 @@ class LdioLdesClientConnectorTest {
 	private final String endpoint = "endpoint";
 	private TransferService transferService;
 	private TokenService tokenService;
-	private LdioLdesClient ldesClient;
 
 	@BeforeEach
 	void setup() {
 		transferService = mock(TransferService.class);
 		tokenService = mock(TokenService.class);
-		ldesClient = mock(LdioLdesClient.class);
+		final LdioLdesClient ldesClient = mock(LdioLdesClient.class);
 
 		eventPublisher.publishEvent(new LdesClientConnectorApiCreatedEvent(endpoint, new LdioLdesClientConnectorApi(transferService, tokenService, ldesClient)));
 	}


### PR DESCRIPTION
A nullpointer exception was thrown when the pipelinestatus has changed of non-connector pipeline