### PR TITLE
fix: improve log messages when statements cannot be found in model

### DIFF
--- a/ldi-core/version-object-creator/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/VersionObjectCreatorTest.java
+++ b/ldi-core/version-object-creator/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/VersionObjectCreatorTest.java
@@ -217,27 +217,6 @@ class VersionObjectCreatorTest {
 				.containsExactlyInAnyOrder(expectedMessages);
 	}
 
-	@Test
-	void when_modelIsEmpty_warningMessagesAreLogged() {
-		Logger vocLogger = (Logger) LoggerFactory.getLogger(VersionObjectCreator.class);
-		ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-		listAppender.start();
-		vocLogger.addAppender(listAppender);
-
-		VersionObjectCreator versionObjectCreator = new VersionObjectCreator(new EmptyPropertyExtractor(), null,
-				DEFAULT_DELIMITER,
-				null, null);
-		versionObjectCreator.transform(ModelFactory.createDefaultModel());
-
-		List<ILoggingEvent> logsList = listAppender.list;
-		assertThat(logsList)
-				.extracting(ILoggingEvent::getMessage)
-				.containsExactlyInAnyOrder(LINKED_DATA_MODEL_IS_EMPTY, DATE_OBSERVED_PROPERTY_COULD_NOT_BE_FOUND);
-		assertThat(logsList)
-				.extracting(ILoggingEvent::getLevel)
-				.containsOnly(Level.WARN);
-	}
-
 	private String getPartOfLocalDateTime(LocalDateTime time) {
 		return time.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:"));
 	}


### PR DESCRIPTION
The VersionObjectCreator previously contained one log line in case the member info could not be extracted and stated only that the "date observed property could not be found". This was misleading as most of the time the model was just empty and no real error happened.

In this PR, the log statements were improved and now separates the following cases: when the model is empty, the member info could not be extracted and when the date observed property could not be found.