### PR TITLE
docs: reduce documentation padding

### DIFF
--- a/docs/_sass/_layout.scss
+++ b/docs/_sass/_layout.scss
@@ -125,9 +125,7 @@
     width: calc((100% - 90rem) / 2 + 16.5rem);
     min-width: 16.5rem;
   }
-}
 
-@media (min-width: 66.5rem) {
   .main {
     margin-left: Max(16.5rem, calc((100% - 90rem) / 2 + 16.5rem));
   }

--- a/docs/_sass/_layout.scss
+++ b/docs/_sass/_layout.scss
@@ -119,3 +119,16 @@
   color: #008000;
   font-weight: normal;
 }
+
+@media (min-width: 66.5rem) {
+  .side-bar {
+    width: calc((100% - 90rem) / 2 + 16.5rem);
+    min-width: 16.5rem;
+  }
+}
+
+@media (min-width: 66.5rem) {
+  .main {
+    margin-left: Max(16.5rem, calc((100% - 90rem) / 2 + 16.5rem));
+  }
+}

--- a/docs/_sass/theme.scss
+++ b/docs/_sass/theme.scss
@@ -215,6 +215,10 @@ a:link a:visited a:hover a:active {
 
 }
 
+.main {
+    max-width: 66.5rem!important;
+}
+
 .main-content {
     margin-top: 100px;
 }


### PR DESCRIPTION
When the screen width exceeds 66.5rem, the padding is reduced to maximize the available screen real estate for the documentation content.