### PR TITLE
fix: same request is sent twice

### DIFF
--- a/docs/_includes/ldio-core/rdf-writer.md
+++ b/docs/_includes/ldio-core/rdf-writer.md
@@ -1,12 +1,14 @@
-### Additional RDF Writer Properties
+### RDF Writer Properties
 
 | Property                | Description                                                      | Required | Default     | Supported values                                                                                                        | Example                                                           |
 |:------------------------|:-----------------------------------------------------------------|:---------|:------------|:------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------|
 | rdf-writer.content-type | Target content type.                                             | No       | text/turtle | Any type supported by [Apache Jena](https://jena.apache.org/documentation/io/rdf-input.html#determining-the-rdf-syntax) | application/ld+json                                               |
 | rdf-writer.frame        | Additional JSON-LD Frame to format the outputted JSON-LD Object. | No       | N/A         | Any valid JSON Object that describes a JSON-LD Frame                                                                    | See https://www.w3.org/TR/json-ld11-framing/#sample-library-frame |
 
-### RDF Writer Example
+<details>
+    <summary>Example RDF Writer config</summary>
 
+<div markdown="1">
 Format as N-Quads:
 
 ```yaml
@@ -33,3 +35,8 @@ Format as JSON-LD with given frame:
               }
             }
 ```
+</div>
+
+
+</details>
+

--- a/docs/_ldio/ldio-outputs/ldio-http-out.md
+++ b/docs/_ldio/ldio-outputs/ldio-http-out.md
@@ -17,3 +17,5 @@ The LDIO HTTP Out is a basic Http Client that will send the given Linked Data mo
 | endpoint   | Target url.           | Yes      | N/A          | http://example.com/endpoint | HTTP and HTTPS urls                                   |
 
 {% include ldio-core/rdf-writer.md %}
+
+{% include ldio-core/http-requester.md %}

--- a/ldi-orchestrator/ldio-connectors/ldio-http-out/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioHttpOut.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-http-out/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioHttpOut.java
@@ -41,13 +41,15 @@ public class LdioHttpOut implements LdiOutput {
 			final String contentType = rdfWriterProperties.getLang().getHeaderString();
 			final RequestHeader requestHeader = new RequestHeader(HttpHeaders.CONTENT_TYPE, contentType);
 			final PostRequest request = new PostRequest(targetURL, new RequestHeaders(List.of(requestHeader)), output.toByteArray());
-			Response response = requestExecutor.execute(request);
-			if (response.isSuccess()) {
-				log.debug("{} {} {}", request.getMethod(), request.getUrl(), response.getHttpStatus());
-			} else {
-				log.atError().log("Failed to post model. The request url was {}. " +
-						"The http response obtained from the server has code {} and body \"{}\".",
-						response.getRequestedUrl(), response.getHttpStatus(), response.getBodyAsString().orElse(null));
+			synchronized (requestExecutor) {
+				Response response = requestExecutor.execute(request);
+				if (response.isSuccess()) {
+					log.debug("{} {} {}", request.getMethod(), request.getUrl(), response.getHttpStatus());
+				} else {
+					log.atError().log("Failed to post model. The request url was {}. " +
+									  "The http response obtained from the server has code {} and body \"{}\".",
+							response.getRequestedUrl(), response.getHttpStatus(), response.getBodyAsString().orElse(null));
+				}
 			}
 		}
 	}

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorApi.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorApi.java
@@ -10,7 +10,6 @@ public class LdioLdesClientConnectorApi {
 	private final TokenService tokenService;
 	private final LdioLdesClient ldesClient;
 
-	@SuppressWarnings("java:S107")
 	public LdioLdesClientConnectorApi(TransferService transferService, TokenService tokenService, LdioLdesClient ldesClient) {
 		this.transferService = transferService;
 		this.tokenService = tokenService;


### PR DESCRIPTION
During the examples set up, it was noticed in the server that an unexpected DuplicateKeyException was received. After doing some ingestion, it was noticed that some members were indeed sent twice and others not, which must have been a threading issue. This is now resolved with using the synchronized keyword in the `LdioHttpOut` component