### PR TITLE
fix: deadlock in the ldes client connector

### DIFF
--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorApi.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorApi.java
@@ -3,17 +3,13 @@ package be.vlaanderen.informatievlaanderen.ldes.ldio;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.edc.services.TokenService;
 import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.executor.edc.services.TransferService;
 
-import static be.vlaanderen.informatievlaanderen.ldes.ldio.pipeline.status.PipelineStatusTrigger.START;
-
 public class LdioLdesClientConnectorApi {
 	private final TransferService transferService;
 	private final TokenService tokenService;
-	private final LdioLdesClient ldesClient;
 
-	public LdioLdesClientConnectorApi(TransferService transferService, TokenService tokenService, LdioLdesClient ldesClient) {
+	public LdioLdesClientConnectorApi(TransferService transferService, TokenService tokenService) {
 		this.transferService = transferService;
 		this.tokenService = tokenService;
-		this.ldesClient = ldesClient;
 	}
 
 	public void handleToken(String token) {
@@ -21,10 +17,7 @@ public class LdioLdesClientConnectorApi {
 	}
 
 	public String handleTransfer(String transfer) {
-		String response = transferService.startTransfer(transfer).getBodyAsString()
-				.orElse("");
-		ldesClient.updateStatus(START);
-		return response;
+		return transferService.startTransfer(transfer).getBodyAsString().orElse("");
 	}
 
 	public void shutdown() {

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/config/LdioLdesClientConnectorAutoConfig.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/config/LdioLdesClientConnectorAutoConfig.java
@@ -71,6 +71,7 @@ public class LdioLdesClientConnectorAutoConfig {
 					urlProxy);
 			final var eventStreamPropertiesFetcher = new EventStreamPropertiesFetcher(edcRequestExecutor);
 			final var clientStatusConsumer = new ClientStatusConsumer(pipelineName, clientStatusService);
+			eventPublisher.publishEvent(new LdesClientConnectorApiCreatedEvent(pipelineName, new LdioLdesClientConnectorApi(transferService, tokenService)));
 			final MemberSupplier memberSupplier = new MemberSupplierFactory(
 					ldioLdesClientProperties,
 					eventStreamPropertiesFetcher,
@@ -82,8 +83,6 @@ public class LdioLdesClientConnectorAutoConfig {
 			final LdioObserver ldioObserver = LdioObserver.register(NAME, pipelineName, observationRegistry);
 			final var ldesClient = new LdioLdesClient(executor, ldioObserver, memberSupplier,
 					applicationEventPublisher, keepState, clientStatusConsumer);
-			eventPublisher.publishEvent(new LdesClientConnectorApiCreatedEvent(pipelineName, new LdioLdesClientConnectorApi(transferService, tokenService, ldesClient)));
-
 			ldesClient.start();
 			return ldesClient;
 		}

--- a/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorTest.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-ldes-client-connector/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldio/LdioLdesClientConnectorTest.java
@@ -39,9 +39,8 @@ class LdioLdesClientConnectorTest {
 	void setup() {
 		transferService = mock(TransferService.class);
 		tokenService = mock(TokenService.class);
-		final LdioLdesClient ldesClient = mock(LdioLdesClient.class);
 
-		eventPublisher.publishEvent(new LdesClientConnectorApiCreatedEvent(endpoint, new LdioLdesClientConnectorApi(transferService, tokenService, ldesClient)));
+		eventPublisher.publishEvent(new LdesClientConnectorApiCreatedEvent(endpoint, new LdioLdesClientConnectorApi(transferService, tokenService)));
 	}
 
 	@Test


### PR DESCRIPTION
In contrary of the discussed solution, I figured that the injection of the ldesClient in the LdioLdesClientConnectorApi could be dropped completely, as the client was and still is started in the configurator. In addition, fetching the ldes properties now makes sure the wait process for the token has been started.