### PR TITLE
chore/redo-gzip-asking-client

### DIFF
--- a/ldi-core/ldes-client/tree-node-fetcher/src/main/java/ldes/client/treenodefetcher/domain/valueobjects/TreeNodeRequest.java
+++ b/ldi-core/ldes-client/tree-node-fetcher/src/main/java/ldes/client/treenodefetcher/domain/valueobjects/TreeNodeRequest.java
@@ -7,8 +7,6 @@ import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.
 import org.apache.http.HttpHeaders;
 import org.apache.jena.riot.Lang;
 
-import java.util.List;
-
 /**
  * Contains the endpoint to connect to the server. This can only be a fragment
  */
@@ -25,8 +23,10 @@ public class TreeNodeRequest {
 	}
 
 	public Request createRequest() {
-		RequestHeaders requestHeaders = new RequestHeaders(
-				List.of(new RequestHeader(HttpHeaders.ACCEPT, lang.getHeaderString())));
+		RequestHeaders requestHeaders = RequestHeaders.of(
+				new RequestHeader(HttpHeaders.ACCEPT, lang.getHeaderString()),
+				new RequestHeader(HttpHeaders.ACCEPT_ENCODING, "gzip")
+		);
 		if (etag != null) {
 			requestHeaders = requestHeaders.withRequestHeader(new RequestHeader(HttpHeaders.IF_NONE_MATCH, etag));
 		}

--- a/ldi-core/ldes-client/tree-node-fetcher/src/test/java/ldes/client/treenodefetcher/domain/valueobjects/TreeNodeRequestTest.java
+++ b/ldi-core/ldes-client/tree-node-fetcher/src/test/java/ldes/client/treenodefetcher/domain/valueobjects/TreeNodeRequestTest.java
@@ -1,0 +1,55 @@
+package ldes.client.treenodefetcher.domain.valueobjects;
+
+import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.GetRequest;
+import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.Request;
+import be.vlaanderen.informatievlaanderen.ldes.ldi.requestexecutor.valueobjects.RequestHeader;
+import org.apache.jena.riot.Lang;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TreeNodeRequestTest {
+	private static final String URL = "http://example.com";
+	private static final Lang LANG = Lang.TTL;
+
+
+	@Test
+	void test_BasicCreate() {
+		final TreeNodeRequest treeNodeRequest = new TreeNodeRequest(URL, LANG, "");
+
+		final Request result = treeNodeRequest.createRequest();
+
+		assertThat(result)
+				.isInstanceOf(GetRequest.class)
+				.extracting(Request::getUrl)
+				.isEqualTo(URL);
+	}
+
+	@Test
+	void given_EtagIsNull_when_CreateRequest_then_RequestContainsTwoHeaders() {
+		final TreeNodeRequest treeNodeRequest = new TreeNodeRequest(URL, LANG, null);
+
+		final Request result = treeNodeRequest.createRequest();
+
+		assertThat(result.getRequestHeaders())
+				.containsExactlyInAnyOrder(
+						new RequestHeader("Accept", LANG.getHeaderString()),
+						new RequestHeader("Accept-Encoding", "gzip")
+				);
+	}
+
+	@Test
+	void given_EtagIsNonNull_when_CreateRequest_then_RequestContainsThreeHeaders() {
+		final String etag = "my-etag";
+		final TreeNodeRequest treeNodeRequest = new TreeNodeRequest(URL, LANG, etag);
+
+		final Request result = treeNodeRequest.createRequest();
+
+		assertThat(result.getRequestHeaders())
+				.containsExactlyInAnyOrder(
+						new RequestHeader("Accept", LANG.getHeaderString()),
+						new RequestHeader("If-None-Match", etag),
+						new RequestHeader("Accept-Encoding", "gzip")
+				);
+	}
+}

--- a/ldi-core/request-executor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/requestexecutor/valueobjects/RequestHeaders.java
+++ b/ldi-core/request-executor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/requestexecutor/valueobjects/RequestHeaders.java
@@ -27,6 +27,10 @@ public class RequestHeaders implements Iterable<RequestHeader> {
 		return new RequestHeaders(new ArrayList<>());
 	}
 
+	public static RequestHeaders of(RequestHeader... requestHeaders) {
+		return new RequestHeaders(Arrays.asList(requestHeaders));
+	}
+
 	@Override
 	public Iterator<RequestHeader> iterator() {
 		return headers.iterator();

--- a/ldi-core/request-executor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/requestexecutor/valueobjects/RequestHeadersTest.java
+++ b/ldi-core/request-executor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/requestexecutor/valueobjects/RequestHeadersTest.java
@@ -5,18 +5,44 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RequestHeadersTest {
 
+	private static final String CONTENT_TYPE = "application/json";
+
 	@Test
 	void getFirst() {
-		final String contentType = "application/json";
-		final List<RequestHeader> requestHeaders = List.of(new RequestHeader("content-type", contentType));
+		final List<RequestHeader> requestHeaders = List.of(new RequestHeader("content-type", CONTENT_TYPE));
 		Optional<String> firstHeader = new RequestHeaders(requestHeaders).getFirst("cOnTenT-TYPE")
 				.map(RequestHeader::getValue);
 		assertTrue(firstHeader.isPresent());
-		assertEquals(contentType, firstHeader.get());
+		assertEquals(CONTENT_TYPE, firstHeader.get());
 	}
 
+	@Test
+	void test_Of() {
+		final RequestHeaders actual = RequestHeaders.of(new RequestHeader("content-type", CONTENT_TYPE), new RequestHeader("User-Agent", "Ldio:LdesClient"));
+
+		assertThat(actual).containsExactlyInAnyOrder(
+				new RequestHeader("content-type", CONTENT_TYPE),
+				new RequestHeader("User-Agent", "Ldio:LdesClient")
+		);
+	}
+
+	@Test
+	void test_WithRequestHeader() {
+		final RequestHeaders start = RequestHeaders.of(new RequestHeader("content-type", CONTENT_TYPE));
+
+		assertThat(start).hasSize(1);
+
+		final RequestHeaders result = start.withRequestHeader(new RequestHeader("User-Agent", "Ldio:LdesClient"));
+
+		assertThat(result).containsExactlyInAnyOrder(
+				new RequestHeader("content-type", CONTENT_TYPE),
+				new RequestHeader("User-Agent", "Ldio:LdesClient")
+		);
+	}
 }

--- a/ldi-nifi/ldi-nifi-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/services/RequestExecutorSupplier.java
+++ b/ldi-nifi/ldi-nifi-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/services/RequestExecutorSupplier.java
@@ -29,18 +29,16 @@ public class RequestExecutorSupplier {
 	}
 
 	private RequestExecutor getBaseRequestExecutor(final ProcessContext context) {
-		final BasicHeader acceptEncodingHeader = new BasicHeader("Accept-Encoding", "gzip");
 		return switch (getAuthorizationStrategy(context)) {
-			case NO_AUTH -> requestExecutorFactory.createNoAuthExecutor(List.of(acceptEncodingHeader));
+			case NO_AUTH -> requestExecutorFactory.createNoAuthExecutor();
 			case API_KEY -> {
 				List<Header> headers = List.of(
-						acceptEncodingHeader,
 						new BasicHeader(getApiKeyHeader(context), getApiKey(context))
 				);
 				yield requestExecutorFactory.createNoAuthExecutor(headers);
 			}
 			case OAUTH2_CLIENT_CREDENTIALS ->
-					requestExecutorFactory.createClientCredentialsExecutor(List.of(acceptEncodingHeader), getOauthClientId(context),
+					requestExecutorFactory.createClientCredentialsExecutor(getOauthClientId(context),
 							getOauthClientSecret(context), getOauthTokenEndpoint(context), getOauthScope(context));
 		};
 	}

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClientProcessorTest.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClientProcessorTest.java
@@ -2,6 +2,7 @@ package be.vlaanderen.informatievlaanderen.ldes.ldi.processors;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
@@ -50,6 +51,7 @@ class LdesClientProcessorTest {
 
 	@AfterAll
 	static void afterAll() {
+		WireMock.verify(RequestPatternBuilder.allRequests().withHeader("Accept-Encoding", WireMock.matching("gzip")));
 		postgreSQLContainer.stop();
 	}
 

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClientProcessorTest.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/LdesClientProcessorTest.java
@@ -2,7 +2,6 @@ package be.vlaanderen.informatievlaanderen.ldes.ldi.processors;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
@@ -51,7 +50,6 @@ class LdesClientProcessorTest {
 
 	@AfterAll
 	static void afterAll() {
-		WireMock.verify(RequestPatternBuilder.allRequests().withHeader("Accept-Encoding", WireMock.matching("gzip")));
 		postgreSQLContainer.stop();
 	}
 

--- a/ldi-orchestrator/ldio-connectors/ldio-request-executor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/requestexecutor/LdioRequestExecutorSupplier.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-request-executor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/requestexecutor/LdioRequestExecutorSupplier.java
@@ -106,7 +106,7 @@ public class LdioRequestExecutorSupplier {
 
     private List<Header> getHttpHeaders(ComponentProperties componentProperties) {
         final ComponentProperties headers = componentProperties.extractNestedProperties(HTTP_HEADERS);
-        final List<Header> result = new ArrayList<>(List.of(new BasicHeader(HTTP_ACCEPT_ENCODING_HEADER_KEY, HTTP_ACCEPT_ENCODING_HEADER_VALUE)));
+        final List<Header> result = new ArrayList<>();
         for (int i = 0; isNotEmpty(headers.extractNestedProperties(String.valueOf(i)).getConfig()); i++) {
             ComponentProperties headerProperties = headers.extractNestedProperties(String.valueOf(i));
             BasicHeader basicHeader = new BasicHeader(

--- a/ldi-orchestrator/ldio-connectors/ldio-request-executor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/requestexecutor/RequestExecutorProperties.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-request-executor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldio/requestexecutor/RequestExecutorProperties.java
@@ -10,8 +10,6 @@ public class RequestExecutorProperties {
     public static final String HTTP_HEADERS_VALUE = "value";
     public static final String HTTP_METHOD = "http.method";
     public static final String HTTP_CONTENT_TYPE = "http.content-type";
-    public static final String HTTP_ACCEPT_ENCODING_HEADER_KEY = "Accept-Encoding";
-    public static final String HTTP_ACCEPT_ENCODING_HEADER_VALUE = "gzip";
 
     public static final String RETRIES_ENABLED = "retries.enabled";
     public static final String MAX_RETRIES = "retries.max";

--- a/ldi-orchestrator/ldio-connectors/ldio-request-executor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldio/requestexecutor/LdioRequestExecutorSupplierTest.java
+++ b/ldi-orchestrator/ldio-connectors/ldio-request-executor/src/test/java/be/vlaanderen/informatievlaanderen/ldes/ldio/requestexecutor/LdioRequestExecutorSupplierTest.java
@@ -94,7 +94,6 @@ class LdioRequestExecutorSupplierTest {
 		RequestExecutor requestExecutor = mock(RequestExecutor.class);
 		List<Header> expectedHeaders =
 				List.of(
-						new BasicHeaderWithEquals("Accept-Encoding", "gzip"),
 						new BasicHeaderWithEquals("header-key", "header-value"),
 						new BasicHeaderWithEquals("other-header-key", "other-header-value"),
 						new BasicHeaderWithEquals("key-header", "key")
@@ -144,7 +143,7 @@ class LdioRequestExecutorSupplierTest {
 				CLIENT_SECRET, "secret",
 				TOKEN_ENDPOINT, "token"));
 		RequestExecutor requestExecutor = mock(RequestExecutor.class);
-		when(requestExecutorFactory.createClientCredentialsExecutor(List.of(new BasicHeaderWithEquals("Accept-Encoding", "gzip")), "client", "secret", "token", null))
+		when(requestExecutorFactory.createClientCredentialsExecutor(List.of(), "client", "secret", "token", null))
 				.thenReturn(requestExecutor);
 
 		RequestExecutor result = requestExecutorSupplier.getRequestExecutor(properties);


### PR DESCRIPTION
In #719 the client was configured to always ask for gzip content. However, it was not a very clean approach, as it required to update the same config on different places. This has been redone in this PR