### PR TITLE
chore: NiFi Ldes Client Processor properties are less overwhelming

### DIFF
--- a/docs/_ldi-nifi/index.md
+++ b/docs/_ldi-nifi/index.md
@@ -16,7 +16,7 @@ The processors can be imported into a NiFi docker instance via volume binding:
     ````yaml
     services:
       nifi:
-        image: apache/nifi:2.0.0-M2
+        image: apache/nifi:2.0.0
         environment:
           SINGLE_USER_CREDENTIALS_USERNAME: admin
           SINGLE_USER_CREDENTIALS_PASSWORD: ctsBtRBKHRAx69EqUghvvgEvjnaLjFEB

--- a/ldi-nifi/ldi-nifi-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/config/PersistenceProperties.java
+++ b/ldi-nifi/ldi-nifi-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/config/PersistenceProperties.java
@@ -31,6 +31,7 @@ public class PersistenceProperties {
 			.description("Postgres database url formatted as \"jdbc:postgresql://localhost:5432/postgres\"")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(STATE_PERSISTENCE_STRATEGY, StatePersistenceStrategy.POSTGRES.name())
 			.build();
 
 	public static final PropertyDescriptor POSTGRES_USERNAME = new PropertyDescriptor.Builder()
@@ -39,6 +40,7 @@ public class PersistenceProperties {
 			.description("Username used to connect to the postgres database")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(STATE_PERSISTENCE_STRATEGY, StatePersistenceStrategy.POSTGRES.name())
 			.build();
 
 	public static final PropertyDescriptor POSTGRES_PASSWORD = new PropertyDescriptor.Builder()
@@ -47,6 +49,8 @@ public class PersistenceProperties {
 			.description("Password used to connect to the postgres database")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.sensitive(true)
+			.dependsOn(STATE_PERSISTENCE_STRATEGY, StatePersistenceStrategy.POSTGRES.name())
 			.build();
 
 	public static final PropertyDescriptor SQLITE_DIRECTORY = new PropertyDescriptor.Builder()
@@ -55,12 +59,15 @@ public class PersistenceProperties {
 			.description("Sqlite database directory where the '.db' file can be stored")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(STATE_PERSISTENCE_STRATEGY, StatePersistenceStrategy.SQLITE.name())
 			.build();
 
 	public static final PropertyDescriptor KEEP_STATE = new PropertyDescriptor.Builder()
 			.name("KEEP_STATE")
-			.displayName("Keep state when the processor is removed from the flow")
+			.displayName("Keep state")
+			.description("Keep state when the processor is removed from the flow")
 			.required(false)
+			.allowableValues(TRUE.toString(), FALSE.toString())
 			.addValidator(StandardValidators.BOOLEAN_VALIDATOR)
 			.defaultValue(FALSE.toString())
 			.build();

--- a/ldi-nifi/ldi-nifi-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/config/RequestExecutorProperties.java
+++ b/ldi-nifi/ldi-nifi-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/config/RequestExecutorProperties.java
@@ -18,6 +18,16 @@ public class RequestExecutorProperties {
 	private RequestExecutorProperties() {
 	}
 
+	public static final PropertyDescriptor AUTHORIZATION_STRATEGY = new PropertyDescriptor.Builder()
+			.name("AUTHORIZATION_STRATEGY")
+			.displayName("Authorization strategy")
+			.description("Authorization strategy for the internal http client.")
+			.required(true)
+			.defaultValue(AuthStrategy.NO_AUTH.name())
+			.allowableValues(Arrays.stream(AuthStrategy.values()).map(Enum::name).collect(Collectors.toSet()))
+			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.build();
+
 	public static final PropertyDescriptor API_KEY_HEADER_PROPERTY = new PropertyDescriptor.Builder()
 			.name("API_KEY_HEADER_PROPERTY")
 			.displayName("API-KEY header property")
@@ -25,6 +35,7 @@ public class RequestExecutorProperties {
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
 			.defaultValue("X-API-KEY")
+			.dependsOn(AUTHORIZATION_STRATEGY, AuthStrategy.API_KEY.name())
 			.build();
 
 	public static final PropertyDescriptor API_KEY_PROPERTY = new PropertyDescriptor.Builder()
@@ -33,6 +44,7 @@ public class RequestExecutorProperties {
 			.description("API key that should be used to access the API.")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(AUTHORIZATION_STRATEGY, AuthStrategy.API_KEY.name())
 			.build();
 
 	public static final PropertyDescriptor OAUTH_CLIENT_ID = new PropertyDescriptor.Builder()
@@ -41,6 +53,7 @@ public class RequestExecutorProperties {
 			.description("Client id used for Oauth2 client credentials flow")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(AUTHORIZATION_STRATEGY, AuthStrategy.OAUTH2_CLIENT_CREDENTIALS.name())
 			.build();
 
 	public static final PropertyDescriptor OAUTH_CLIENT_SECRET = new PropertyDescriptor.Builder()
@@ -50,6 +63,7 @@ public class RequestExecutorProperties {
 			.sensitive(true)
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(AUTHORIZATION_STRATEGY, AuthStrategy.OAUTH2_CLIENT_CREDENTIALS.name())
 			.build();
 
 	public static final PropertyDescriptor OAUTH_TOKEN_ENDPOINT = new PropertyDescriptor.Builder()
@@ -58,6 +72,7 @@ public class RequestExecutorProperties {
 			.description("Token endpoint used for Oauth2 client credentials flow.")
 			.required(false)
 			.addValidator(StandardValidators.URL_VALIDATOR)
+			.dependsOn(AUTHORIZATION_STRATEGY, AuthStrategy.OAUTH2_CLIENT_CREDENTIALS.name())
 			.build();
 
 	public static final PropertyDescriptor OAUTH_SCOPE = new PropertyDescriptor.Builder()
@@ -66,16 +81,7 @@ public class RequestExecutorProperties {
 			.description("Scope used for Oauth2 client credentials flow.")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-			.build();
-
-	public static final PropertyDescriptor AUTHORIZATION_STRATEGY = new PropertyDescriptor.Builder()
-			.name("AUTHORIZATION_STRATEGY")
-			.displayName("Authorization strategy")
-			.description("Authorization strategy for the internal http client.")
-			.required(true)
-			.defaultValue(AuthStrategy.NO_AUTH.name())
-			.allowableValues(Arrays.stream(AuthStrategy.values()).map(Enum::name).collect(Collectors.toSet()))
-			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(AUTHORIZATION_STRATEGY, AuthStrategy.OAUTH2_CLIENT_CREDENTIALS.name())
 			.build();
 
 	public static final PropertyDescriptor RETRIES_ENABLED = new PropertyDescriptor.Builder()
@@ -95,6 +101,7 @@ public class RequestExecutorProperties {
 			.required(false)
 			.defaultValue(String.valueOf(5))
 			.addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+			.dependsOn(RETRIES_ENABLED, TRUE.toString())
 			.build();
 
 	public static final PropertyDescriptor STATUSES_TO_RETRY = new PropertyDescriptor.Builder()
@@ -103,6 +110,7 @@ public class RequestExecutorProperties {
 			.description("Custom comma seperated list of http status codes that can trigger a retry in the http client.")
 			.required(false)
 			.addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+			.dependsOn(RETRIES_ENABLED, TRUE.toString())
 			.build();
 
 	public static String getApiKeyHeader(final ProcessContext context) {

--- a/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/config/LdesProcessorProperties.java
+++ b/ldi-nifi/ldi-nifi-processors/ldes-client-processor/src/main/java/be/vlaanderen/informatievlaanderen/ldes/ldi/processors/config/LdesProcessorProperties.java
@@ -101,10 +101,11 @@ public final class LdesProcessorProperties {
 	public static final PropertyDescriptor USE_LATEST_STATE_FILTER = new PropertyDescriptor.Builder()
 			.name("USE_LATEST_STATE_FILTER")
 			.displayName("Use latest state filter")
-			.description("Use filter to only process the latest state and so all older versions are ignored, only when 'Use version materialisation' is set to true")
+			.description("Use filter to only process the latest state and so all older versions are ignored")
 			.required(false)
 			.addValidator(StandardValidators.BOOLEAN_VALIDATOR)
 			.defaultValue(TRUE.toString())
+			.dependsOn(USE_VERSION_MATERIALISATION, TRUE.toString())
 			.build();
 
 	public static List<String> getDataSourceUrl(final ProcessContext context) {


### PR DESCRIPTION
This PR marks POSTGRES_PASSWORD as a sensitive property. In addition, it structures the properties a little better in the UI by making some of the properties dependant